### PR TITLE
Adds Support for Remaining CORS Annotations

### DIFF
--- a/pkg/i2gw/implementations/kgateway/README.md
+++ b/pkg/i2gw/implementations/kgateway/README.md
@@ -49,6 +49,11 @@ The command should generate Gateway API and Kgateway resources.
 - `nginx.ingress.kubernetes.io/proxy-body-size`
 - `nginx.ingress.kubernetes.io/enable-cors`
 - `nginx.ingress.kubernetes.io/cors-allow-origin`
+- `nginx.ingress.kubernetes.io/cors-allow-credentials`
+- `nginx.ingress.kubernetes.io/cors-allow-headers`
+- `nginx.ingress.kubernetes.io/cors-expose-headers`
+- `nginx.ingress.kubernetes.io/cors-allow-methods`
+- `nginx.ingress.kubernetes.io/cors-max-age`
 - `nginx.ingress.kubernetes.io/limit-rps`
 - `nginx.ingress.kubernetes.io/limit-rpm`
 - `nginx.ingress.kubernetes.io/limit-burst-multiplier`
@@ -78,6 +83,7 @@ The command should generate Gateway API and Kgateway resources.
 - `nginx.ingress.kubernetes.io/auth-secret`: Specifies the secret containing basic auth credentials in `namespace/name` format (or just `name` if in the same namespace). Maps to `TrafficPolicy.spec.basicAuth.secretRef.name`.
 
 ### Access Logging
+
 - `nginx.ingress.kubernetes.io/enable-access-log`: If enabled, will create an HTTPListenerPolicy that will configure a basic policy for envoy access logging. Maps to `HTTPListenerPolicy.spec.accessLog[].fileSink`. This can be further customized as needed, see [docs](https://kgateway.dev/docs/envoy/2.0.x/security/access-logging/).
 
 ## TrafficPolicy Projection
@@ -121,8 +127,7 @@ the lowest timeout wins and a warning is emitted.
 - Only the **ingress-nginx provider** is currently supported by the Kgateway emitter.
 - Some NGINX behaviors cannot be reproduced exactly due to Envoy/Kgateway differences.
 
-
-## Supported but not tranlated Annotations 
+## Supported but not tranlated Annotations
 
 The following annotations have equivalents in kgateway but are not (as of yet) translated by this tool.
 
@@ -130,7 +135,7 @@ The following annotations have equivalents in kgateway but are not (as of yet) t
 
 Supported in TrafficPolicy
 
-```
+```yaml
 spec:
   extAuth:
     httpService:
@@ -139,5 +144,3 @@ spec:
         - key: x-forwarded-host
           value: "%DOWNSTREAM_REMOTE_ADDRESS%"
 ```
-
-

--- a/pkg/i2gw/implementations/kgateway/cors.go
+++ b/pkg/i2gw/implementations/kgateway/cors.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kgateway
+
+import (
+	"strings"
+
+	"github.com/kgateway-dev/ingress2gateway/pkg/i2gw/intermediate"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// applyCorsPolicy projects the CORS policy IR into a Kgateway TrafficPolicy,
+// returning true if it modified/created a TrafficPolicy for the given ingress.
+func applyCorsPolicy(
+	pol intermediate.Policy,
+	ingressName, namespace string,
+	tp map[string]*kgateway.TrafficPolicy,
+) bool {
+	if pol.Cors == nil || !pol.Cors.Enable || len(pol.Cors.AllowOrigin) == 0 {
+		return false
+	}
+
+	// AllowOrigins: dedupe while preserving order.
+	seenOrigins := make(map[string]struct{}, len(pol.Cors.AllowOrigin))
+	var origins []gwv1.CORSOrigin
+	for _, o := range pol.Cors.AllowOrigin {
+		o = strings.TrimSpace(o)
+		if o == "" {
+			continue
+		}
+		if _, ok := seenOrigins[o]; ok {
+			continue
+		}
+		seenOrigins[o] = struct{}{}
+		origins = append(origins, gwv1.CORSOrigin(o))
+	}
+	if len(origins) == 0 {
+		return false
+	}
+
+	// AllowHeaders: dedupe (case-insensitive) and map to HTTPHeaderName.
+	var allowHeaders []gwv1.HTTPHeaderName
+	if len(pol.Cors.AllowHeaders) > 0 {
+		seenHeaders := make(map[string]struct{}, len(pol.Cors.AllowHeaders))
+		for _, h := range pol.Cors.AllowHeaders {
+			h = strings.TrimSpace(h)
+			if h == "" {
+				continue
+			}
+			key := strings.ToLower(h)
+			if _, ok := seenHeaders[key]; ok {
+				continue
+			}
+			seenHeaders[key] = struct{}{}
+			allowHeaders = append(allowHeaders, gwv1.HTTPHeaderName(h))
+		}
+	}
+
+	// ExposeHeaders: dedupe (case-insensitive) and map to HTTPHeaderName.
+	var exposeHeaders []gwv1.HTTPHeaderName
+	if len(pol.Cors.ExposeHeaders) > 0 {
+		seenHeaders := make(map[string]struct{}, len(pol.Cors.ExposeHeaders))
+		for _, h := range pol.Cors.ExposeHeaders {
+			h = strings.TrimSpace(h)
+			if h == "" {
+				continue
+			}
+			key := strings.ToLower(h)
+			if _, ok := seenHeaders[key]; ok {
+				continue
+			}
+			seenHeaders[key] = struct{}{}
+			exposeHeaders = append(exposeHeaders, gwv1.HTTPHeaderName(h))
+		}
+	}
+
+	// AllowMethods: normalize to upper-case, filter to Gateway API enum, dedupe.
+	var methods []gwv1.HTTPMethodWithWildcard
+	if len(pol.Cors.AllowMethods) > 0 {
+		seenMethods := make(map[string]struct{}, len(pol.Cors.AllowMethods))
+		for _, m := range pol.Cors.AllowMethods {
+			m = strings.TrimSpace(m)
+			if m == "" {
+				continue
+			}
+			upper := strings.ToUpper(m)
+			if _, ok := seenMethods[upper]; ok {
+				continue
+			}
+
+			switch upper {
+			case "*",
+				string(gwv1.HTTPMethodGet),
+				string(gwv1.HTTPMethodHead),
+				string(gwv1.HTTPMethodPost),
+				string(gwv1.HTTPMethodPut),
+				string(gwv1.HTTPMethodDelete),
+				string(gwv1.HTTPMethodConnect),
+				string(gwv1.HTTPMethodOptions),
+				string(gwv1.HTTPMethodTrace),
+				string(gwv1.HTTPMethodPatch):
+				methods = append(methods, gwv1.HTTPMethodWithWildcard(upper))
+				seenMethods[upper] = struct{}{}
+			default:
+				// Ignore unsupported method strings to avoid generating invalid objects.
+			}
+		}
+	}
+
+	t := ensureTrafficPolicy(tp, ingressName, namespace)
+
+	if t.Spec.Cors == nil {
+		t.Spec.Cors = &kgateway.CorsPolicy{}
+	}
+	if t.Spec.Cors.HTTPCORSFilter == nil {
+		t.Spec.Cors.HTTPCORSFilter = &gwv1.HTTPCORSFilter{}
+	}
+
+	f := t.Spec.Cors.HTTPCORSFilter
+
+	// Required-ish for nginx semantics: we only emit if we have at least one origin.
+	f.AllowOrigins = origins
+
+	// Optional knobs: only set when present in the IR.
+	if pol.Cors.AllowCredentials != nil {
+		f.AllowCredentials = pol.Cors.AllowCredentials
+	}
+	if len(allowHeaders) > 0 {
+		f.AllowHeaders = allowHeaders
+	}
+	if len(exposeHeaders) > 0 {
+		f.ExposeHeaders = exposeHeaders
+	}
+	if len(methods) > 0 {
+		f.AllowMethods = methods
+	}
+	if pol.Cors.MaxAge != nil && *pol.Cors.MaxAge > 0 {
+		f.MaxAge = *pol.Cors.MaxAge
+	}
+
+	return true
+}

--- a/pkg/i2gw/implementations/kgateway/emitter_integration_test.go
+++ b/pkg/i2gw/implementations/kgateway/emitter_integration_test.go
@@ -119,19 +119,14 @@ func canonicalizeMultiDocYAML(t *testing.T, in []byte) []byte {
 	return buf.Bytes()
 }
 
-func TestKgatewayIngressNginxIntegration_Golden(t *testing.T) {
+// runGoldenTest is a reusable helper for feature-scoped integration tests.
+func runGoldenTest(t *testing.T, inputRel, goldenRel string) {
 	t.Helper()
 
 	moduleRoot := getModuleRoot(t)
 
-	inputPath := filepath.Join(
-		moduleRoot,
-		"pkg", "i2gw", "implementations", "kgateway", "testing", "testdata", "input.yaml",
-	)
-	goldenPath := filepath.Join(
-		moduleRoot,
-		"pkg", "i2gw", "implementations", "kgateway", "testing", "testdata", "output.yaml",
-	)
+	inputPath := filepath.Join(moduleRoot, inputRel)
+	goldenPath := filepath.Join(moduleRoot, goldenRel)
 
 	cmd := exec.Command(
 		"go", "run", ".",
@@ -182,5 +177,40 @@ func TestKgatewayIngressNginxIntegration_Golden(t *testing.T) {
 
 	if diff := cmp.Diff(string(want), string(got)); diff != "" {
 		t.Fatalf("golden output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestKgatewayIngressNginxIntegration_Golden(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name      string
+		inputRel  string
+		goldenRel string
+	}{
+		{
+			name: "all_features",
+			inputRel: filepath.Join(
+				"pkg", "i2gw", "implementations", "kgateway", "testing", "testdata", "input", "golden.yaml",
+			),
+			goldenRel: filepath.Join(
+				"pkg", "i2gw", "implementations", "kgateway", "testing", "testdata", "output", "golden.yaml",
+			),
+		},
+		{
+			name: "cors",
+			inputRel: filepath.Join(
+				"pkg", "i2gw", "implementations", "kgateway", "testing", "testdata", "input", "cors.yaml",
+			),
+			goldenRel: filepath.Join(
+				"pkg", "i2gw", "implementations", "kgateway", "testing", "testdata", "output", "cors.yaml",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runGoldenTest(t, tt.inputRel, tt.goldenRel)
+		})
 	}
 }

--- a/pkg/i2gw/implementations/kgateway/testing/testdata/input/cors.yaml
+++ b/pkg/i2gw/implementations/kgateway/testing/testdata/input/cors.yaml
@@ -1,0 +1,74 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    ingress2gateway.kubernetes.io/implementation: kgateway
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://example.com, https://another.com"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "X-Requested-With, Content-Type"
+    nginx.ingress.kubernetes.io/cors-expose-headers: "X-Expose-One, X-Expose-Two"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-max-age: "600"
+  name: ingress-myservicea1
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: myservicea.foo.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: myservicea
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    ingress2gateway.kubernetes.io/implementation: kgateway
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://example.com, https://another.com"
+  name: ingress-myservicea2
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: myservicea.foo.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: myservicea
+            port:
+              number: 80
+        path: /2
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    ingress2gateway.kubernetes.io/implementation: kgateway
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://example.com, https://another.com"
+    nginx.ingress.kubernetes.io/cors-expose-headers: "*, X-CustomResponseHeader"
+  name: ingress-myserviceb
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: myserviceb.foo.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: myserviceb
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/pkg/i2gw/implementations/kgateway/testing/testdata/input/golden.yaml
+++ b/pkg/i2gw/implementations/kgateway/testing/testdata/input/golden.yaml
@@ -4,8 +4,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
     ingress2gateway.kubernetes.io/implementation: kgateway
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://example.com, https://another.com"
     nginx.ingress.kubernetes.io/limit-rpm: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "30s"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "45s"
@@ -35,8 +33,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/client-body-buffer-size: 20m
     ingress2gateway.kubernetes.io/implementation: kgateway
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://example.com, https://another.com"
     nginx.ingress.kubernetes.io/limit-rps: "10"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60" # No "s" suffix, should still be parsed correctly
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60" # No "s" suffix, should still be parsed correctly
@@ -62,8 +58,6 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/client-body-buffer-size: 40m
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://example.com, https://another.com"
     ingress2gateway.kubernetes.io/implementation: kgateway
     nginx.ingress.kubernetes.io/limit-rps: "50"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"

--- a/pkg/i2gw/implementations/kgateway/testing/testdata/output/cors.yaml
+++ b/pkg/i2gw/implementations/kgateway/testing/testdata/output/cors.yaml
@@ -1,0 +1,142 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - hostname: myservicea.foo.org
+    name: myservicea-foo-org-http
+    port: 80
+    protocol: HTTP
+  - hostname: myserviceb.foo.org
+    name: myserviceb-foo-org-http
+    port: 80
+    protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-myservicea1-myservicea-foo-org
+  namespace: default
+spec:
+  hostnames:
+  - myservicea.foo.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - filters:
+      - extensionRef:
+          group: gateway.kgateway.dev
+          kind: TrafficPolicy
+          name: ingress-myservicea1
+        type: ExtensionRef
+      name: myservicea
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+  - backendRefs:
+    - filters:
+      - extensionRef:
+          group: gateway.kgateway.dev
+          kind: TrafficPolicy
+          name: ingress-myservicea2
+        type: ExtensionRef
+      name: myservicea
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /2
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-myserviceb-myserviceb-foo-org
+  namespace: default
+spec:
+  hostnames:
+  - myserviceb.foo.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: myserviceb
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: ingress-myservicea1
+  namespace: default
+spec:
+  cors:
+    allowOrigins:
+    - https://example.com
+    - https://another.com
+    allowCredentials: false
+    allowMethods:
+    - GET
+    - POST
+    - OPTIONS
+    allowHeaders:
+    - X-Requested-With
+    - Content-Type
+    exposeHeaders:
+    - X-Expose-One
+    - X-Expose-Two
+    maxAge: 600
+status:
+  ancestors: null
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: ingress-myservicea2
+  namespace: default
+spec:
+  cors:
+    allowOrigins:
+    - https://example.com
+    - https://another.com
+status:
+  ancestors: null
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: ingress-myserviceb
+  namespace: default
+spec:
+  cors:
+    allowOrigins:
+    - https://example.com
+    - https://another.com
+    exposeHeaders:
+    - "*"
+    - X-CustomResponseHeader
+  targetRefs:
+  - group: ""
+    kind: ""
+    name: ingress-myserviceb-myserviceb-foo-org
+status:
+  ancestors: null

--- a/pkg/i2gw/implementations/kgateway/testing/testdata/output/golden.yaml
+++ b/pkg/i2gw/implementations/kgateway/testing/testdata/output/golden.yaml
@@ -220,10 +220,6 @@ metadata:
 spec:
   buffer:
     maxRequestSize: 10m
-  cors:
-    allowOrigins:
-    - https://example.com
-    - https://another.com
   extAuth:
     extensionRef:
       name: auth-example-com-extauth
@@ -248,10 +244,6 @@ metadata:
 spec:
   buffer:
     maxRequestSize: 20m
-  cors:
-    allowOrigins:
-    - https://example.com
-    - https://another.com
   rateLimit:
     local:
       tokenBucket:
@@ -275,10 +267,6 @@ spec:
       name: basic-auth-secret
   buffer:
     maxRequestSize: 100m
-  cors:
-    allowOrigins:
-    - https://example.com
-    - https://another.com
   rateLimit:
     local:
       tokenBucket:

--- a/pkg/i2gw/intermediate/provider_ingressnginx.go
+++ b/pkg/i2gw/intermediate/provider_ingressnginx.go
@@ -41,8 +41,34 @@ type PolicyIndex struct {
 
 // CorsPolicy defines a CORS policy that has been extracted from ingress-nginx annotations.
 type CorsPolicy struct {
-	Enable      bool
+	// Enable corresponds to nginx.ingress.kubernetes.io/enable-cors and indicates whether CORS
+	// is enabled.
+	Enable bool
+
+	// AllowOrigin corresponds to nginx.ingress.kubernetes.io/cors-allow-origin and controls what
+	// is the accepted Origin for CORS.
 	AllowOrigin []string
+
+	// AllowCredentials corresponds to nginx.ingress.kubernetes.io/cors-allow-credentials and controls
+	// if credentials can be passed during CORS operations. When nil, the provider has not specified a value.
+	AllowCredentials *bool
+
+	// AllowHeaders corresponds to nginx.ingress.kubernetes.io/cors-allow-headers and controls which
+	// headers are accepted. Values are stored as raw header names; case-insensitivity is handled by consumers.
+	AllowHeaders []string
+
+	// ExposeHeaders corresponds to nginx.ingress.kubernetes.io/cors-expose-headers.
+	// Values are header names as they appeared in the annotation, trimmed of
+	// surrounding whitespace but otherwise case-preserving.
+	ExposeHeaders []string
+
+	// AllowMethods corresponds to nginx.ingress.kubernetes.io/cors-allow-methods and controls which methods
+	// are accepted. Values are stored as raw method names; consumers can normalize/validate.
+	AllowMethods []string
+
+	// MaxAge corresponds to nginx.ingress.kubernetes.io/cors-max-age, in seconds and controls how long preflight
+	// requests can be cached. When nil, the provider has not specified a value.
+	MaxAge *int32
 }
 
 // ExtAuthPolicy defines an external authentication policy that has been extracted from ingress-nginx annotations.
@@ -80,9 +106,12 @@ type SessionAffinityPolicy struct {
 type Policy struct {
 	// ClientBodyBufferSize defines the size of the buffer used for client request bodies.
 	ClientBodyBufferSize *resource.Quantity
+
 	// ProxyBodySize defines the maximum allowed size of the client request body.
 	ProxyBodySize *resource.Quantity
-	Cors          *CorsPolicy
+
+	// Cors defines the CORS policy derived from ingress-nginx annotations.
+	Cors *CorsPolicy
 
 	// RateLimit is a generic rate limit policy derived from ingress-nginx annotations.
 	RateLimit *RateLimitPolicy
@@ -108,6 +137,13 @@ type Policy struct {
 	// SessionAffinity defines the session affinity policy.
 	SessionAffinity *SessionAffinityPolicy
 
+	// RuleBackendSources lists the (rule, backend) pairs within a merged HTTPRoute
+	// that this policy applies to.
+	//
+	// Each entry is a PolicyIndex struct identifying a (rule, backend) pair.
+	//
+	// This slice may contain duplicates; use AddRuleBackendSources to add entries
+	// while ensuring uniqueness.
 	RuleBackendSources []PolicyIndex
 
 	// ruleBackendIndexSet is an internal helper used to deduplicate RuleBackendSources entries.

--- a/pkg/i2gw/providers/ingressnginx/README.md
+++ b/pkg/i2gw/providers/ingressnginx/README.md
@@ -36,11 +36,20 @@ The ingress-nginx provider currently supports translating the following annotati
 
 ### CORS
 
-- `nginx.ingress.kubernetes.io/enable-cors`: Enables CORS policy generation.
-
-- `nginx.ingress.kubernetes.io/cors-allow-origin`: Comma-separated list of origins. For the Kgateway implementation, this maps to `TrafficPolicy.spec.cors.allowOrigins`.
-
----
+- `nginx.ingress.kubernetes.io/enable-cors`: Enables CORS policy generation. When set to "true", enables CORS handling for the Ingress.
+  Maps to creation of a TrafficPolicy with `spec.cors` populated.
+- `nginx.ingress.kubernetes.io/cors-allow-origin`: Comma-separated list of origins (e.g. "https://example.com, https://another.com").
+  For the Kgateway implementation, this maps to `TrafficPolicy.spec.cors.allowOrigins`.
+- `nginx.ingress.kubernetes.io/cors-allow-credentials`: Controls whether credentials are allowed in cross-origin requests ("true" / "false").
+  For the Kgateway implementation, this maps to `TrafficPolicy.spec.cors.allowCredentials`.
+- `nginx.ingress.kubernetes.io/cors-allow-headers`: A comma-separated list of allowed request headers. For the Kgateway implementation,
+  this maps to `TrafficPolicy.spec.cors.allowHeaders`.
+- `nginx.ingress.kubernetes.io/cors-expose-headers`: A comma-separated list of HTTP response headers that can be exposed to client-side
+  scripts in response to a cross-origin request. For the Kgateway implementation, this maps to `TrafficPolicy.spec.cors.exposeHeaders`.
+- `nginx.ingress.kubernetes.io/cors-allow-methods`: A comma-separated list of allowed HTTP methods (e.g. "GET, POST, OPTIONS").
+  For the Kgateway implementation, this maps to `TrafficPolicy.spec.cors.allowMethods`.
+- `nginx.ingress.kubernetes.io/cors-max-age`: Controls how long preflight responses may be cached (in seconds). For the Kgateway
+  implementation, this maps to `TrafficPolicy.spec.cors.maxAge`.
 
 ### Rate Limiting
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

- Adds support for the remaining Ingress NGINX CORS annotations.
- Splits out kgtw emitter test data input/output files per feature.
- Refactors kgtw emitter integration test suite to use different input/output test data files.
- Splits out CORS feature into a separate file for the kgtw emitter.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Adds support for the remaining Ingress NGINX CORS annotations: `nginx.ingress.kubernetes.io/cors-allow-credentials`,  `nginx.ingress.kubernetes.io/cors-allow-headers`, `nginx.ingress.kubernetes.io/cors-expose-headers`, `nginx.ingress.kubernetes.io/cors-allow-methods`, and `nginx.ingress.kubernetes.io/cors-max-age`.
```
