### PR TITLE
e2e: Fixes Session Affinity Path

### DIFF
--- a/pkg/i2gw/implementations/kgateway/testing/testdata/input/session_affinity.yaml
+++ b/pkg/i2gw/implementations/kgateway/testing/testdata/input/session_affinity.yaml
@@ -24,5 +24,5 @@ spec:
             name: httpbin
             port:
               number: 80
-        path: /
+        path: /path/one
         pathType: Prefix

--- a/pkg/i2gw/implementations/kgateway/testing/testdata/output/session_affinity.yaml
+++ b/pkg/i2gw/implementations/kgateway/testing/testdata/output/session_affinity.yaml
@@ -33,7 +33,7 @@ spec:
     matches:
     - path:
         type: PathPrefix
-        value: /
+        value: /path/one
 status:
   parents: []
 ---

--- a/test/e2e/emitters/kgateway/testdata/output/session_affinity.yaml
+++ b/test/e2e/emitters/kgateway/testdata/output/session_affinity.yaml
@@ -31,7 +31,7 @@ spec:
     matches:
     - path:
         type: PathPrefix
-        value: /
+        value: /session/affinity
 status:
   parents: []
 ---


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds the correct path (generated by i2g based on the associated input file) to `test/e2e/emitters/kgateway/testdata/output/session_affinity.yaml`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
N/A
```
