### PR TITLE
Run i2g in e2e

### DIFF
--- a/test/e2e/emitters/kgateway/i2g.go
+++ b/test/e2e/emitters/kgateway/i2g.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kgateway
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.yaml.in/yaml/v4"
+)
+
+// runIngress2Gateway runs ingress2gateway against the input file and returns the generated YAML output.
+func runIngress2Gateway(ctx context.Context, root, inputFile string) ([]byte, error) {
+	cmd := exec.CommandContext(
+		ctx,
+		"go", "run", ".",
+		"print",
+		"--providers=ingress-nginx",
+		"--implementations=kgateway",
+		"--input-file", inputFile,
+	)
+	cmd.Dir = root
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ingress2gateway command failed: %w\nstderr:\n%s", err, stderr.String())
+	}
+
+	return stdout.Bytes(), nil
+}
+
+// canonicalizeMultiDocYAML normalizes YAML by sorting documents by kind, namespace, and name.
+// This makes YAML comparison more reliable by eliminating ordering differences.
+func canonicalizeMultiDocYAML(in []byte) ([]byte, error) {
+	// Split multi-doc YAML into individual docs.
+	dec := yaml.NewDecoder(bytes.NewReader(in))
+
+	type doc struct {
+		Raw map[string]any
+	}
+	var docs []doc
+
+	for {
+		var m map[string]any
+		if err := dec.Decode(&m); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("failed to decode yaml: %w", err)
+		}
+		if len(m) == 0 {
+			continue
+		}
+		docs = append(docs, doc{Raw: m})
+	}
+
+	// Extract Kind/Name for sorting.
+	type keyedDoc struct {
+		kind      string
+		namespace string
+		name      string
+		raw       map[string]any
+	}
+
+	var kd []keyedDoc
+	for _, d := range docs {
+		md, _ := d.Raw["metadata"].(map[string]any)
+		kind, _ := d.Raw["kind"].(string)
+		name, _ := md["name"].(string)
+		ns, _ := md["namespace"].(string)
+		kd = append(kd, keyedDoc{
+			kind:      kind,
+			namespace: ns,
+			name:      name,
+			raw:       d.Raw,
+		})
+	}
+
+	sort.Slice(kd, func(i, j int) bool {
+		if kd[i].kind != kd[j].kind {
+			return kd[i].kind < kd[j].kind
+		}
+		if kd[i].namespace != kd[j].namespace {
+			return kd[i].namespace < kd[j].namespace
+		}
+		return kd[i].name < kd[j].name
+	})
+
+	// Re-encode in canonical order.
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+
+	for _, d := range kd {
+		if err := enc.Encode(d.raw); err != nil {
+			return nil, fmt.Errorf("failed to encode yaml: %w", err)
+		}
+	}
+	_ = enc.Close()
+
+	return buf.Bytes(), nil
+}
+
+// compareAndGenerateOutput runs ingress2gateway, compares the output with expected output,
+// and writes the generated output to a temporary file. Returns the path to the generated output file.
+func compareAndGenerateOutput(ctx context.Context, t *testing.T, root, inputFile, expectedOutputFile string) (string, error) {
+	t.Helper()
+
+	// Run ingress2gateway to generate output
+	generatedYAML, err := runIngress2Gateway(ctx, root, inputFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to run ingress2gateway: %w", err)
+	}
+
+	// Read expected output
+	expectedYAML, err := os.ReadFile(expectedOutputFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read expected output file %q: %w", expectedOutputFile, err)
+	}
+
+	// Canonicalize both YAMLs for comparison
+	generatedCanonical, err := canonicalizeMultiDocYAML(bytes.TrimSpace(generatedYAML))
+	if err != nil {
+		return "", fmt.Errorf("failed to canonicalize generated YAML: %w", err)
+	}
+
+	expectedCanonical, err := canonicalizeMultiDocYAML(bytes.TrimSpace(expectedYAML))
+	if err != nil {
+		return "", fmt.Errorf("failed to canonicalize expected YAML: %w", err)
+	}
+
+	// Compare canonicalized outputs
+	if diff := cmp.Diff(string(expectedCanonical), string(generatedCanonical)); diff != "" {
+		t.Fatalf("generated output does not match expected output (-want +got):\n%s", diff)
+	}
+
+	// Write generated output to a temporary file
+	tmpFile, err := os.CreateTemp("", "i2g-generated-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.Write(generatedYAML); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to write generated YAML to temp file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	return tmpPath, nil
+}

--- a/test/e2e/emitters/kgateway/testdata/input/cors.yaml
+++ b/test/e2e/emitters/kgateway/testdata/input/cors.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: cors2.localdev.me
+  - host: cors.localdev.me
     http:
       paths:
       - path: /

--- a/test/e2e/emitters/kgateway/testdata/output/cors.yaml
+++ b/test/e2e/emitters/kgateway/testdata/output/cors.yaml
@@ -11,21 +11,17 @@ spec:
     name: cors-localdev-me-http
     port: 80
     protocol: HTTP
-  - hostname: cors2.localdev.me
-    name: cors2-localdev-me-http
-    port: 80
-    protocol: HTTP
 status: {}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ingress-cors-b-cors2-localdev-me
+  name: ingress-cors-b-cors-localdev-me
   annotations:
     gateway.networking.k8s.io/generator: ingress2gateway-dev
 spec:
   hostnames:
-  - cors2.localdev.me
+  - cors.localdev.me
   parentRefs:
   - name: nginx
   rules:
@@ -54,6 +50,6 @@ spec:
   targetRefs:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
-    name: ingress-cors-b-cors2-localdev-me
+    name: ingress-cors-b-cors-localdev-me
 status:
   ancestors: null


### PR DESCRIPTION
- Added `i2g.go` to handle ingress2gateway execution and YAML processing.
- Updated `e2e_test.go` to generate and compare output using the new functionality.
- Modified expected output in `cors.yaml` to reflect changes in the test setup.

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #29

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
