### PR TITLE
Fix data race in NotificationAggregator (#292)

### DIFF
--- a/pkg/i2gw/notifications/notifications.go
+++ b/pkg/i2gw/notifications/notifications.go
@@ -70,6 +70,9 @@ func (na *NotificationAggregator) DispatchNotification(notification Notification
 func (na *NotificationAggregator) CreateNotificationTables() map[string]string {
 	notificationTablesMap := make(map[string]string)
 
+	na.mutex.Lock()
+	defer na.mutex.Unlock()
+
 	for provider, msgs := range na.Notifications {
 		providerTable := strings.Builder{}
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

We have a read operation on a shared map without using a mutex in CreateNotificationTables.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
