### PR TITLE
Adds Traffic Timeout Support to Agentgateway Emitter

### DIFF
--- a/pkg/i2gw/emitters/agentgateway/README.md
+++ b/pkg/i2gw/emitters/agentgateway/README.md
@@ -51,6 +51,24 @@ The command should generate Gateway API resources plus agentgateway extension re
 
 ### Traffic Behavior
 
+#### Request Timeouts
+
+The agentgateway emitter currently supports projecting request timeouts based on the following Ingress NGINX annotations:
+
+- `nginx.ingress.kubernetes.io/proxy-send-timeout`
+- `nginx.ingress.kubernetes.io/proxy-read-timeout`
+
+These are mapped into an `AgentgatewayPolicy` using agentgateway’s `Traffic.Timeouts` model:
+
+- `proxy-send-timeout` → `AgentgatewayPolicy.spec.traffic.timeouts.request`
+- `proxy-read-timeout` → `AgentgatewayPolicy.spec.traffic.timeouts.request`
+
+**Notes:**
+
+- If **both** annotations are set, the emitter uses the **larger** of the two values for
+  `spec.traffic.timeouts.request` to avoid unexpectedly truncating requests.
+- Invalid/unsupported duration values are ignored by the provider and will not be projected.
+
 #### Local Rate Limiting
 
 The agentgateway emitter currently supports projecting local rate limiting via:
@@ -72,7 +90,7 @@ These are mapped into an `AgentgatewayPolicy` using agentgateway’s `LocalRateL
 
 ## AgentgatewayPolicy Projection
 
-Rate limit annotations are converted into `AgentgatewayPolicy` resources.
+Rate limit and timeout annotations are converted into `AgentgatewayPolicy` resources.
 
 ### Naming
 

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/input/timeouts.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/input/timeouts.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "30s"
+  name: ingress-timeout-proxy-send
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: timeout-proxy-send.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: myservice
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "45s"
+  name: ingress-timeout-proxy-read
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: timeout-proxy-read.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: myservice
+            port:
+              number: 80
+        path: /read
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "15s"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60s"
+  name: ingress-timeout-send-and-read
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: timeout-send-and-read.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: myservice
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/output/timeouts.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/output/timeouts.yaml
@@ -1,0 +1,140 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - hostname: timeout-proxy-read.example.org
+    name: timeout-proxy-read-example-org-http
+    port: 80
+    protocol: HTTP
+  - hostname: timeout-proxy-send.example.org
+    name: timeout-proxy-send-example-org-http
+    port: 80
+    protocol: HTTP
+  - hostname: timeout-send-and-read.example.org
+    name: timeout-send-and-read-example-org-http
+    port: 80
+    protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-timeout-proxy-read-timeout-proxy-read-example-org
+  namespace: default
+spec:
+  hostnames:
+  - timeout-proxy-read.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: myservice
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /read
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-timeout-proxy-send-timeout-proxy-send-example-org
+  namespace: default
+spec:
+  hostnames:
+  - timeout-proxy-send.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: myservice
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-timeout-send-and-read-timeout-send-and-read-example-org
+  namespace: default
+spec:
+  hostnames:
+  - timeout-send-and-read.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: myservice
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-timeout-proxy-read
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-timeout-proxy-read-timeout-proxy-read-example-org
+  traffic:
+    timeouts:
+      request: 45s
+status:
+  ancestors: null
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-timeout-proxy-send
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-timeout-proxy-send-timeout-proxy-send-example-org
+  traffic:
+    timeouts:
+      request: 30s
+status:
+  ancestors: null
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-timeout-send-and-read
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-timeout-send-and-read-timeout-send-and-read-example-org
+  traffic:
+    timeouts:
+      request: 1m0s
+status:
+  ancestors: null

--- a/pkg/i2gw/emitters/agentgateway/timeouts.go
+++ b/pkg/i2gw/emitters/agentgateway/timeouts.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentgateway
+
+import (
+	agentgatewayv1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/agentgateway"
+
+	providerir "github.com/kgateway-dev/ingress2gateway/pkg/i2gw/provider_intermediate"
+)
+
+// applyTimeoutPolicy projects timeout-related Policy IR into an AgentgatewayPolicy,
+// returning true if it modified/created an AgentgatewayPolicy for this ingress.
+//
+// AgentgatewayPolicy exposes a single request timeout at traffic.timeouts.request.
+// NGINX has separate proxy-send-timeout and proxy-read-timeout knobs; we conservatively
+// choose the larger of the two when both are set.
+func applyTimeoutPolicy(
+	pol providerir.Policy,
+	ingressName, namespace string,
+	ap map[string]*agentgatewayv1alpha1.AgentgatewayPolicy,
+) bool {
+	if pol.ProxyReadTimeout == nil && pol.ProxySendTimeout == nil {
+		return false
+	}
+
+	agp := ensureAgentgatewayPolicy(ap, ingressName, namespace)
+	if agp.Spec.Traffic == nil {
+		agp.Spec.Traffic = &agentgatewayv1alpha1.Traffic{}
+	}
+	if agp.Spec.Traffic.Timeouts == nil {
+		agp.Spec.Traffic.Timeouts = &agentgatewayv1alpha1.Timeouts{}
+	}
+
+	// Pick the most permissive timeout to avoid unexpectedly truncating requests.
+	timeout := pol.ProxySendTimeout
+	if timeout == nil || (pol.ProxyReadTimeout != nil && pol.ProxyReadTimeout.Duration > timeout.Duration) {
+		timeout = pol.ProxyReadTimeout
+	}
+
+	agp.Spec.Traffic.Timeouts.Request = timeout
+	ap[ingressName] = agp
+	return true
+}

--- a/test/e2e/emitters/agentgateway/e2e_test.go
+++ b/test/e2e/emitters/agentgateway/e2e_test.go
@@ -241,3 +241,29 @@ func TestRateLimit(t *testing.T) {
 		Timeout:            1 * time.Minute,
 	})
 }
+
+func TestTimeouts(t *testing.T) {
+	_, gwAddr, host, ingressHostHeader, ingressIP := e2eTestSetup(t, "timeouts.yaml", "timeouts.yaml")
+
+	// Test HTTP connectivity via Ingress
+	testutils.MakeHTTPRequestEventually(t, kubeContext, testutils.HTTPRequestConfig{
+		HostHeader:         ingressHostHeader,
+		Scheme:             "http",
+		Address:            ingressIP,
+		Port:               "",
+		Path:               "/",
+		ExpectedStatusCode: 200,
+		Timeout:            1 * time.Minute,
+	})
+
+	// Test HTTP connectivity via Gateway
+	testutils.MakeHTTPRequestEventually(t, kubeContext, testutils.HTTPRequestConfig{
+		HostHeader:         host,
+		Scheme:             "http",
+		Address:            gwAddr,
+		Port:               "80",
+		Path:               "/",
+		ExpectedStatusCode: 200,
+		Timeout:            1 * time.Minute,
+	})
+}

--- a/test/e2e/emitters/agentgateway/testdata/input/timeouts.yaml
+++ b/test/e2e/emitters/agentgateway/testdata/input/timeouts.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "30s"
+  name: ingress-timeout-proxy-send
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: timeout-proxy-send.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: echo-backend
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "45s"
+  name: ingress-timeout-proxy-read
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: timeout-proxy-read.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: echo-backend
+            port:
+              number: 8080
+        path: /read
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "15s"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60s"
+  name: ingress-timeout-send-and-read
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: timeout-send-and-read.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: echo-backend
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/test/e2e/emitters/agentgateway/testdata/output/timeouts.yaml
+++ b/test/e2e/emitters/agentgateway/testdata/output/timeouts.yaml
@@ -1,0 +1,140 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - hostname: timeout-proxy-read.example.org
+    name: timeout-proxy-read-example-org-http
+    port: 80
+    protocol: HTTP
+  - hostname: timeout-proxy-send.example.org
+    name: timeout-proxy-send-example-org-http
+    port: 80
+    protocol: HTTP
+  - hostname: timeout-send-and-read.example.org
+    name: timeout-send-and-read-example-org-http
+    port: 80
+    protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-timeout-proxy-send-timeout-proxy-send-example-org
+  namespace: default
+spec:
+  hostnames:
+  - timeout-proxy-send.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: echo-backend
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-timeout-send-and-read-timeout-send-and-read-example-org
+  namespace: default
+spec:
+  hostnames:
+  - timeout-send-and-read.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: echo-backend
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-timeout-proxy-read-timeout-proxy-read-example-org
+  namespace: default
+spec:
+  hostnames:
+  - timeout-proxy-read.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: echo-backend
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /read
+status:
+  parents: []
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-timeout-proxy-read
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-timeout-proxy-read-timeout-proxy-read-example-org
+  traffic:
+    timeouts:
+      request: 45s
+status:
+  ancestors: null
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-timeout-proxy-send
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-timeout-proxy-send-timeout-proxy-send-example-org
+  traffic:
+    timeouts:
+      request: 30s
+status:
+  ancestors: null
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-timeout-send-and-read
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-timeout-send-and-read-timeout-send-and-read-example-org
+  traffic:
+    timeouts:
+      request: 1m0s
+status:
+  ancestors: null


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind documentation
/kind feature
/kind test

**What this PR does / why we need it**:

Adds support for Ingress NGINX `nginx.ingress.kubernetes.io/proxy-send-timeout` and `nginx.ingress.kubernetes.io/proxy-read-timeout` annotations to the agentgateway emitter.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
xref #59 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
agentgateway emitter: Adds support for Ingress NGINX `nginx.ingress.kubernetes.io/proxy-send-timeout` and `nginx.ingress.kubernetes.io/proxy-read-timeout` annotations.
```
