### PR TITLE
Adds Basic Auth to Agentgateway Emitter

### DIFF
--- a/pkg/i2gw/emitters/agentgateway/basic_auth.go
+++ b/pkg/i2gw/emitters/agentgateway/basic_auth.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentgateway
+
+import (
+	"fmt"
+
+	"github.com/kgateway-dev/ingress2gateway/pkg/i2gw/notifications"
+	providerir "github.com/kgateway-dev/ingress2gateway/pkg/i2gw/provider_intermediate"
+
+	agentgatewayv1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/agentgateway"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// basicAuthSecretKey de-dupes notifications across routes/policies.
+type basicAuthSecretKey struct {
+	Namespace string
+	Secret    string
+}
+
+// applyBasicAuthPolicy projects the BasicAuth IR policy into an AgentgatewayPolicy,
+// returning true if it modified/created an AgentgatewayPolicy for the provided ingress.
+//
+// Semantics:
+//   - If BasicAuth is configured, set spec.traffic.basicAuthentication.secretRef.name
+//     to the referenced Secret.
+//
+// Note:
+//   - Agentgateway expects the Secret to contain a key named '.htaccess' with htpasswd
+//     content (per the BasicAuthentication API docs). The emitter cannot validate or
+//     rewrite Secret contents at generation time.
+func applyBasicAuthPolicy(
+	pol providerir.Policy,
+	ingressName, namespace string,
+	ap map[string]*agentgatewayv1alpha1.AgentgatewayPolicy,
+) bool {
+	if pol.BasicAuth == nil || pol.BasicAuth.SecretName == "" {
+		return false
+	}
+
+	agp := ensureAgentgatewayPolicy(ap, ingressName, namespace)
+	if agp.Spec.Traffic == nil {
+		agp.Spec.Traffic = &agentgatewayv1alpha1.Traffic{}
+	}
+
+	agp.Spec.Traffic.BasicAuthentication = &agentgatewayv1alpha1.BasicAuthentication{
+		SecretRef: &corev1.LocalObjectReference{
+			Name: pol.BasicAuth.SecretName,
+		},
+	}
+
+	ap[ingressName] = agp
+	return true
+}
+
+// emitBasicAuthSecretNotifications emits an INFO notification whenever the agentgateway emitter
+// projects BasicAuth into an AgentgatewayPolicy to warn users about theSecret key expectations.
+func emitBasicAuthSecretNotifications(
+	pol providerir.Policy,
+	sourceIngressName string,
+	routeNamespace string,
+	seen map[basicAuthSecretKey]struct{},
+) {
+	if pol.BasicAuth == nil || pol.BasicAuth.SecretName == "" {
+		return
+	}
+
+	key := basicAuthSecretKey{
+		Namespace: routeNamespace,
+		Secret:    pol.BasicAuth.SecretName,
+	}
+	if _, ok := seen[key]; ok {
+		return
+	}
+	seen[key] = struct{}{}
+
+	msg := fmt.Sprintf(
+		`Ingress %q uses Basic Auth (nginx.ingress.kubernetes.io/auth-type=basic) and references Secret %s/%s.
+
+ingress2gateway projected this into an AgentgatewayPolicy:
+  spec.traffic.basicAuthentication.secretRef.name: %q
+
+IMPORTANT: Secret key expectations differ by dataplane:
+  - agentgateway expects htpasswd content under key ".htaccess"
+  - ingress-nginx (auth-file) commonly expects htpasswd content under key "auth"
+`,
+		sourceIngressName,
+		routeNamespace,
+		pol.BasicAuth.SecretName,
+		pol.BasicAuth.SecretName,
+	)
+
+	notifications.NotificationAggr.DispatchNotification(
+		notifications.NewNotification(notifications.InfoNotification, msg),
+		"ingress-nginx",
+	)
+}

--- a/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
+++ b/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
@@ -206,3 +206,29 @@ func TestAgentgatewayIngressNginxIntegration_RateLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentgatewayIngressNginxIntegration_BasicAuth(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name      string
+		inputRel  string
+		goldenRel string
+	}{
+		{
+			name: "basic_auth",
+			inputRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "input", "basic_auth.yaml",
+			),
+			goldenRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "output", "basic_auth.yaml",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runGoldenTest(t, tt.inputRel, tt.goldenRel)
+		})
+	}
+}

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/input/basic_auth.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/input/basic_auth.yaml
@@ -1,0 +1,68 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: "basic"
+    nginx.ingress.kubernetes.io/auth-secret: "default/basic-auth-secret"
+  name: ingress-basic-auth-file-default
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: app1.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: app1
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: "basic"
+    nginx.ingress.kubernetes.io/auth-secret: "default/basic-auth-secret"
+    nginx.ingress.kubernetes.io/auth-secret-type: "auth-file"
+  name: ingress-basic-auth-file-explicit
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: app2.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: app2
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: "basic"
+    nginx.ingress.kubernetes.io/auth-secret: "auth-map-secret"
+    nginx.ingress.kubernetes.io/auth-secret-type: "auth-map"
+  name: ingress-basic-auth-map
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: app3.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: app3
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/output/basic_auth.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/output/basic_auth.yaml
@@ -1,0 +1,143 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - hostname: app1.example.org
+    name: app1-example-org-http
+    port: 80
+    protocol: HTTP
+  - hostname: app2.example.org
+    name: app2-example-org-http
+    port: 80
+    protocol: HTTP
+  - hostname: app3.example.org
+    name: app3-example-org-http
+    port: 80
+    protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-basic-auth-file-default-app1-example-org
+  namespace: default
+spec:
+  hostnames:
+  - app1.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: app1
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-basic-auth-file-explicit-app2-example-org
+  namespace: default
+spec:
+  hostnames:
+  - app2.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: app2
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-basic-auth-map-app3-example-org
+  namespace: default
+spec:
+  hostnames:
+  - app3.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: app3
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-basic-auth-file-default
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-basic-auth-file-default-app1-example-org
+  traffic:
+    basicAuthentication:
+      secretRef:
+        name: basic-auth-secret
+status:
+  ancestors: null
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-basic-auth-file-explicit
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-basic-auth-file-explicit-app2-example-org
+  traffic:
+    basicAuthentication:
+      secretRef:
+        name: basic-auth-secret
+status:
+  ancestors: null
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-basic-auth-map
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-basic-auth-map-app3-example-org
+  traffic:
+    basicAuthentication:
+      secretRef:
+        name: auth-map-secret
+status:
+  ancestors: null

--- a/test/e2e/emitters/agentgateway/testdata/input/basic_auth.yaml
+++ b/test/e2e/emitters/agentgateway/testdata/input/basic_auth.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: "basic"
+    nginx.ingress.kubernetes.io/auth-secret: "basic-auth"
+    nginx.ingress.kubernetes.io/auth-secret-type: "auth-file"
+  name: basic-auth-localhost
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: basic-auth.localdev.me
+    http:
+      paths:
+      - backend:
+          service:
+            name: echo-backend
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/test/e2e/emitters/agentgateway/testdata/output/basic_auth.yaml
+++ b/test/e2e/emitters/agentgateway/testdata/output/basic_auth.yaml
@@ -1,0 +1,55 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - hostname: basic-auth.localdev.me
+    name: basic-auth-localdev-me-http
+    port: 80
+    protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: basic-auth-localhost-basic-auth-localdev-me
+  namespace: default
+spec:
+  hostnames:
+  - basic-auth.localdev.me
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: echo-backend
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: basic-auth-localhost
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: basic-auth-localhost-basic-auth-localdev-me
+  traffic:
+    basicAuthentication:
+      secretRef:
+        name: basic-auth
+status:
+  ancestors: null

--- a/test/e2e/emitters/common/install.go
+++ b/test/e2e/emitters/common/install.go
@@ -85,8 +85,8 @@ func InstallSharedBackends(ctx context.Context, kubeContext string, echoImage st
 	// External auth service for external auth tests.
 	testutils.ApplyExternalAuthService(ctx, kubeContext)
 
-	// Create file-based secret for basic auth tests.
-	testutils.CreateBasicAuthFileSecret(ctx, kubeContext, "basic-auth")
+	// Create file-based secret for kgateway and agentgateway emitter basic auth tests.
+	testutils.CreateBasicAuthCombinedSecret(ctx, kubeContext, "basic-auth")
 }
 
 // CleanupKindCluster deletes the kind cluster unless KEEP_KIND_CLUSTER=true.


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind documentation
/kind feature
/kind test

**What this PR does / why we need it**:

Adds basic auth support to the agentgateway emitter.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
xref: #59 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
agentgateway emitter: Adds basic auth support.
```
