### PR TITLE
agentgateway emitter: Adds Ext Auth Support

### DIFF
--- a/pkg/i2gw/emitters/agentgateway/emitter.go
+++ b/pkg/i2gw/emitters/agentgateway/emitter.go
@@ -90,17 +90,26 @@ func (e *Emitter) Emit(ir emitterir.EmitterIR) (i2gw.GatewayResources, field.Err
 
 			touched := false
 
-			// Apply policy features that map to AgentgatewayPolicy.
+			// Apply rate limit policy features that map to AgentgatewayPolicy.
 			if applyRateLimitPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
 				touched = true
 			}
+
+			// Apply timeout policy features that map to AgentgatewayPolicy.
 			if applyTimeoutPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
 				touched = true
 			}
+
 			// CORS maps to AgentgatewayPolicy.spec.traffic.cors.
 			if applyCorsPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
 				touched = true
 			}
+
+			// ExtAuth maps to AgentgatewayPolicy.spec.traffic.extAuth.
+			if applyExtAuthPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
+				touched = true
+			}
+
 			// BasicAuth maps to AgentgatewayPolicy.spec.traffic.basicAuthentication.
 			// Note: agentgateway expects htpasswd content under a '.htaccess' key; see BasicAuthentication docs.
 			if applyBasicAuthPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {

--- a/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
+++ b/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
@@ -233,6 +233,32 @@ func TestAgentgatewayIngressNginxIntegration_BasicAuth(t *testing.T) {
 	}
 }
 
+func TestAgentgatewayIngressNginxIntegration_ExtAuth(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name      string
+		inputRel  string
+		goldenRel string
+	}{
+		{
+			name: "external_auth",
+			inputRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "input", "external_auth.yaml",
+			),
+			goldenRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "output", "external_auth.yaml",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runGoldenTest(t, tt.inputRel, tt.goldenRel)
+		})
+	}
+}
+
 func TestAgentgatewayIngressNginxIntegration_Timeouts(t *testing.T) {
 	t.Helper()
 

--- a/pkg/i2gw/emitters/agentgateway/external_auth.go
+++ b/pkg/i2gw/emitters/agentgateway/external_auth.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentgateway
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	providerir "github.com/kgateway-dev/ingress2gateway/pkg/i2gw/provider_intermediate"
+	agentgatewayv1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/agentgateway"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
+
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// applyExtAuthPolicy projects the ExtAuth IR policy into an AgentgatewayPolicy.
+//
+// Semantics:
+//   - agentgateway supports extAuth natively under AgentgatewayPolicy.spec.traffic.extAuth.
+//   - We parse nginx.ingress.kubernetes.io/auth-url and map it to:
+//     spec.traffic.extAuth.backendRef -> Service reference
+//     spec.traffic.extAuth.http.path  -> constant CEL string literal (when not "/")
+//     spec.traffic.extAuth.http.allowedResponseHeaders -> pol.ExtAuth.ResponseHeaders (when set)
+//
+// Notes:
+//   - External auth URLs (non-.svc) are skipped by this mapping.
+//   - This mapping assumes HTTP-mode external auth (Ingress NGINX auth-url semantics).
+func applyExtAuthPolicy(
+	pol providerir.Policy,
+	ingressName, namespace string,
+	ap map[string]*agentgatewayv1alpha1.AgentgatewayPolicy,
+) bool {
+	if pol.ExtAuth == nil || pol.ExtAuth.AuthURL == "" {
+		return false
+	}
+
+	parsed, err := parseAuthURL(pol.ExtAuth.AuthURL, namespace)
+	if err != nil {
+		// Invalid URL, skip it.
+		return false
+	}
+	if parsed.external {
+		// Skip external URLs; this mapping only references in-cluster Services.
+		return false
+	}
+
+	agp := ensureAgentgatewayPolicy(ap, ingressName, namespace)
+	if agp.Spec.Traffic == nil {
+		agp.Spec.Traffic = &agentgatewayv1alpha1.Traffic{}
+	}
+
+	extAuth := &agentgatewayv1alpha1.ExtAuth{
+		BackendRef: gatewayv1.BackendObjectReference{
+			Name:      gatewayv1.ObjectName(parsed.service),
+			Namespace: ptr.To(gatewayv1.Namespace(parsed.namespace)),
+			Port:      ptr.To(gatewayv1.PortNumber(parsed.port)),
+		},
+		HTTP: &agentgatewayv1alpha1.AgentExtAuthHTTP{},
+	}
+
+	// Only set a constant Path expression if it's not the default "/" to avoid redirect/sign-in edge cases.
+	if parsed.path != "" && parsed.path != "/" {
+		// CEL string literal for a constant path.
+		p := shared.CELExpression(fmt.Sprintf("%q", parsed.path))
+		extAuth.HTTP.Path = &p
+	}
+
+	// Pass selected response headers from the auth service to the upstream backend request.
+	if len(pol.ExtAuth.ResponseHeaders) > 0 {
+		allowed := make([]agentgatewayv1alpha1.ShortString, 0, len(pol.ExtAuth.ResponseHeaders))
+		for _, h := range pol.ExtAuth.ResponseHeaders {
+			h = strings.TrimSpace(h)
+			if h == "" {
+				continue
+			}
+			allowed = append(allowed, agentgatewayv1alpha1.ShortString(h))
+		}
+		if len(allowed) > 0 {
+			extAuth.HTTP.AllowedResponseHeaders = allowed
+		}
+	}
+
+	agp.Spec.Traffic.ExtAuth = extAuth
+	ap[ingressName] = agp
+	return true
+}
+
+// parsedAuthURL contains the fields you can use to build a BackendObjectReference.
+type parsedAuthURL struct {
+	service   string
+	namespace string
+	port      int32
+	path      string
+	external  bool // true if host is not a Kubernetes service
+}
+
+// parseAuthURL parses an nginx.ingress.kubernetes.io/auth-url value into a parsedAuthURL.
+//
+// Expected form (cluster-local service):
+//
+//	http(s)://<svc>.<ns>.svc[:port]/path
+//
+// For non-.svc hosts, this returns external=true (unsupported by this emitter mapping).
+func parseAuthURL(raw string, ingressNS string) (*parsedAuthURL, error) {
+	if raw == "" {
+		return nil, fmt.Errorf("auth-url is empty")
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid auth-url: %w", err)
+	}
+
+	// Default path
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+
+	host := u.Host
+
+	// Split host and port
+	var hostname, portStr string
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+		portStr = p
+	} else {
+		hostname = host
+	}
+
+	// Detect external hostname (not a Kubernetes service)
+	if !strings.Contains(hostname, ".svc") {
+		return &parsedAuthURL{
+			external: true,
+			path:     path,
+		}, nil
+	}
+
+	// Normalize cluster-local suffixes
+	hostname = strings.TrimSuffix(hostname, ".cluster.local")
+	hostname = strings.TrimSuffix(hostname, ".svc")
+
+	parts := strings.Split(hostname, ".")
+	if len(parts) < 1 {
+		return nil, fmt.Errorf("unable to extract service from hostname %q", hostname)
+	}
+
+	service := parts[0]
+
+	// Determine namespace
+	namespace := ingressNS
+	if len(parts) >= 2 {
+		namespace = parts[1]
+	}
+
+	// Port
+	var port int32
+	if portStr != "" {
+		var parsed int
+		fmt.Sscanf(portStr, "%d", &parsed)
+		port = int32(parsed)
+	} else {
+		switch u.Scheme {
+		case "https":
+			port = 443
+		default:
+			port = 80
+		}
+	}
+
+	return &parsedAuthURL{
+		service:   service,
+		namespace: namespace,
+		port:      port,
+		path:      path,
+		external:  false,
+	}, nil
+}

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/input/external_auth.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/input/external_auth.yaml
@@ -1,0 +1,67 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # Full FQDN with default path
+    nginx.ingress.kubernetes.io/auth-url: "http://auth.default.svc.cluster.local"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Token, X-User-ID"
+  name: ingress-auth-full-fqdn
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: app1.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: app1
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # Service in same namespace, short form
+    nginx.ingress.kubernetes.io/auth-url: "http://auth.svc"
+  name: ingress-auth-same-ns
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: app3.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: app3
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # Service in different namespace
+    nginx.ingress.kubernetes.io/auth-url: "https://auth.production.svc.cluster.local:8080/authz"
+  name: ingress-auth-different-ns
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: app4.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: app4
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+---

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/output/external_auth.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/output/external_auth.yaml
@@ -1,0 +1,156 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-auth-different-ns
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: ingress-auth-different-ns-app4-example-org
+  traffic:
+    extAuth:
+      backendRef:
+        name: auth
+        namespace: production
+        port: 8080
+      http:
+        path: '"/authz"'
+status:
+  ancestors: null
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-auth-full-fqdn
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: ingress-auth-full-fqdn-app1-example-org
+  traffic:
+    extAuth:
+      backendRef:
+        name: auth
+        namespace: default
+        port: 80
+      http:
+        allowedResponseHeaders:
+          - X-Auth-Token
+          - X-User-ID
+status:
+  ancestors: null
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ingress-auth-same-ns
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: ingress-auth-same-ns-app3-example-org
+  traffic:
+    extAuth:
+      backendRef:
+        name: auth
+        namespace: default
+        port: 80
+      http: {}
+status:
+  ancestors: null
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - hostname: app1.example.org
+      name: app1-example-org-http
+      port: 80
+      protocol: HTTP
+    - hostname: app3.example.org
+      name: app3-example-org-http
+      port: 80
+      protocol: HTTP
+    - hostname: app4.example.org
+      name: app4-example-org-http
+      port: 80
+      protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-auth-different-ns-app4-example-org
+  namespace: default
+spec:
+  hostnames:
+    - app4.example.org
+  parentRefs:
+    - name: nginx
+  rules:
+    - backendRefs:
+        - name: app4
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-auth-full-fqdn-app1-example-org
+  namespace: default
+spec:
+  hostnames:
+    - app1.example.org
+  parentRefs:
+    - name: nginx
+  rules:
+    - backendRefs:
+        - name: app1
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-auth-same-ns-app3-example-org
+  namespace: default
+spec:
+  hostnames:
+    - app3.example.org
+  parentRefs:
+    - name: nginx
+  rules:
+    - backendRefs:
+        - name: app3
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+status:
+  parents: []

--- a/test/e2e/emitters/agentgateway/testdata/input/external_auth.yaml
+++ b/test/e2e/emitters/agentgateway/testdata/input/external_auth.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: "http://auth-service.default.svc.cluster.local:8080"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Token, X-User-ID"
+  name: external-auth-localhost
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: external-auth.localdev.me
+    http:
+      paths:
+      - backend:
+          service:
+            name: echo-backend
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+

--- a/test/e2e/emitters/agentgateway/testdata/output/external_auth.yaml
+++ b/test/e2e/emitters/agentgateway/testdata/output/external_auth.yaml
@@ -1,0 +1,61 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - hostname: external-auth.localdev.me
+    name: external-auth-localdev-me-http
+    port: 80
+    protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: external-auth-localhost-external-auth-localdev-me
+  namespace: default
+spec:
+  hostnames:
+  - external-auth.localdev.me
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: echo-backend
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: external-auth-localhost
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: external-auth-localhost-external-auth-localdev-me
+  traffic:
+    extAuth:
+      backendRef:
+        name: auth-service
+        namespace: default
+        port: 8080
+      http:
+        allowedResponseHeaders:
+        - X-Auth-Token
+        - X-User-ID
+status:
+  ancestors: null


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind documentation
/kind feature
/kind test

**What this PR does / why we need it**:

Adds external auth support to the agentgateway emitter.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

xref: #59 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
agentgateway emitter: Adds support for external authentication.
```
