### PR TITLE
Agentgateway Emitter: Adds Backend TLS Support

### DIFF
--- a/pkg/i2gw/emitters/agentgateway/backend_tls.go
+++ b/pkg/i2gw/emitters/agentgateway/backend_tls.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentgateway
+
+import (
+	"strings"
+
+	emitterir "github.com/kgateway-dev/ingress2gateway/pkg/i2gw/emitter_intermediate"
+	providerir "github.com/kgateway-dev/ingress2gateway/pkg/i2gw/provider_intermediate"
+
+	agentgatewayv1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/agentgateway"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// applyBackendTLSPolicy projects the BackendTLS IR policy into one or more AgentgatewayPolicies.
+//
+// Semantics:
+//   - We create at most one AgentgatewayPolicy per Service.
+//   - That policy's Spec.Backend.TLS is configured with SNI hostname, client certificate secret,
+//     and verification settings from Policy.BackendTLS.
+//   - TargetRefs are populated with each covered core Service backend (based on RuleBackendSources).
+//
+// Notes:
+//   - Agentgateway backend TLS uses:
+//       - mtlsCertificateRef: Secret containing tls.crt/tls.key (and optional ca.cert)
+//       - caCertificateRefs: ConfigMap refs (not used here)
+//       - insecureSkipVerify: enum (All|Hostname)
+//   - The ingress-nginx IR provides a single SecretName; we map this to mtlsCertificateRef when Verify=true.
+func applyBackendTLSPolicy(
+	pol providerir.Policy,
+	httpRouteKey types.NamespacedName,
+	httpRouteCtx emitterir.HTTPRouteContext,
+	backendTLSPolicies map[types.NamespacedName]*agentgatewayv1alpha1.AgentgatewayPolicy,
+) bool {
+	if pol.BackendTLS == nil {
+		return false
+	}
+
+	backendTLS := pol.BackendTLS
+
+	// Parse secret name (format: "namespace/secretName" or just "secretName").
+	// AgentgatewayPolicy references Secrets by name (same namespace).
+	secretName := backendTLS.SecretName
+	if parts := strings.SplitN(backendTLS.SecretName, "/", 2); len(parts) == 2 {
+		secretName = parts[1]
+	}
+
+	changed := false
+
+	for _, idx := range pol.RuleBackendSources {
+		if idx.Rule >= len(httpRouteCtx.Spec.Rules) {
+			continue
+		}
+		rule := httpRouteCtx.Spec.Rules[idx.Rule]
+		if idx.Backend >= len(rule.BackendRefs) {
+			continue
+		}
+
+		br := rule.BackendRefs[idx.Backend]
+
+		// Only apply to core Services (same semantics as kgateway emitter).
+		if br.BackendRef.Group != nil && *br.BackendRef.Group != "" {
+			continue
+		}
+		if br.BackendRef.Kind != nil && *br.BackendRef.Kind != "" && *br.BackendRef.Kind != "Service" {
+			continue
+		}
+
+		svcName := string(br.BackendRef.Name)
+		if svcName == "" {
+			continue
+		}
+
+		svcKey := types.NamespacedName{
+			Namespace: httpRouteKey.Namespace,
+			Name:      svcName,
+		}
+
+		ap, ok := backendTLSPolicies[svcKey]
+		if !ok {
+			ap = &agentgatewayv1alpha1.AgentgatewayPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svcName + "-backend-tls",
+					Namespace: httpRouteKey.Namespace,
+				},
+				Spec: agentgatewayv1alpha1.AgentgatewayPolicySpec{
+					TargetRefs: []shared.LocalPolicyTargetReferenceWithSectionName{{
+						LocalPolicyTargetReference: shared.LocalPolicyTargetReference{
+							Group: "",
+							Kind:  "Service",
+							Name:  gatewayv1.ObjectName(svcName),
+						},
+					}},
+				},
+			}
+			// Ensure GVK is set for deterministic unstructured conversion.
+			ap.SetGroupVersionKind(AgentgatewayPolicyGVK)
+			backendTLSPolicies[svcKey] = ap
+		}
+
+		if ap.Spec.Backend == nil {
+			ap.Spec.Backend = &agentgatewayv1alpha1.BackendFull{}
+		}
+		if ap.Spec.Backend.TLS == nil {
+			ap.Spec.Backend.TLS = &agentgatewayv1alpha1.BackendTLS{}
+		}
+
+		// Set SNI hostname if specified.
+		if backendTLS.Hostname != "" {
+			ap.Spec.Backend.TLS.Sni = ptr.To(backendTLS.Hostname)
+		}
+
+		// Verification mapping:
+		// - Verify=false => skip verification entirely (closest match: InsecureTLSModeAll).
+		// - Verify=true  => use system roots unless a Secret is provided; if Secret provided, use it for mTLS.
+		if !backendTLS.Verify {
+			ap.Spec.Backend.TLS.InsecureSkipVerify = ptr.To(agentgatewayv1alpha1.InsecureTLSModeAll)
+			// Do not set mTLS secret when verification is disabled (matches kgateway emitter semantics).
+			ap.Spec.Backend.TLS.MtlsCertificateRef = nil
+		} else if secretName != "" {
+			ap.Spec.Backend.TLS.MtlsCertificateRef = []corev1.LocalObjectReference{{
+				Name: secretName,
+			}}
+		}
+
+		changed = true
+	}
+
+	return changed
+}

--- a/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
+++ b/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
@@ -336,3 +336,29 @@ func TestAgentgatewayIngressNginxIntegration_RewriteTarget(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentgatewayIngressNginxIntegration_BackendTLS(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name      string
+		inputRel  string
+		goldenRel string
+	}{
+		{
+			name: "backend_tls",
+			inputRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "input", "backend_tls.yaml",
+			),
+			goldenRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "output", "backend_tls.yaml",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runGoldenTest(t, tt.inputRel, tt.goldenRel)
+		})
+	}
+}

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/input/backend_tls.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/input/backend_tls.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/proxy-ssl-secret: default/base-certificate-tls
+    nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
+    nginx.ingress.kubernetes.io/proxy-ssl-name: "tls.example.com"
+    nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
+  name: ingress-backendtls
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: tls.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: httpbin2
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/proxy-ssl-secret: default/base-certificate-tls
+    nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
+    nginx.ingress.kubernetes.io/proxy-ssl-name: "tls.example.com"
+    nginx.ingress.kubernetes.io/proxy-ssl-verify: "off"
+  name: ingress-backendtls-verify-off
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: insecure-tls.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: httpbin-insecure
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/output/backend_tls.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/output/backend_tls.yaml
@@ -1,0 +1,65 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - hostname: insecure-tls.example.org
+    name: insecure-tls-example-org-http
+    port: 80
+    protocol: HTTP
+  - hostname: tls.example.org
+    name: tls-example-org-http
+    port: 80
+    protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-backendtls-verify-off-insecure-tls-example-org
+  namespace: default
+spec:
+  hostnames:
+  - insecure-tls.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: httpbin-insecure
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-backendtls-tls-example-org
+  namespace: default
+spec:
+  hostnames:
+  - tls.example.org
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: httpbin2
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind documentation
/kind feature
/kind test

**What this PR does / why we need it**:

Adds backend TLS support to the agentgateway emitter.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

xref: #59

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Agentgateway Emitter: Adds support for backend TLS.
```
