### PR TITLE
Flake: Only Call `FirstRouteHost()` When Header is Unset

### DIFF
--- a/test/e2e/emitters/agentgateway/e2e_test.go
+++ b/test/e2e/emitters/agentgateway/e2e_test.go
@@ -31,6 +31,7 @@ import (
 var (
 	e2eSetupComplete bool
 	kubeContext      = common.KubeContext
+	defaultHostHeader   = common.DefaultHostHeader
 )
 
 func TestMain(m *testing.M) {
@@ -127,7 +128,7 @@ func e2eTestSetup(t *testing.T, inputFile, outputFile string) (context.Context, 
 		}
 	}
 	if hostHeader == "" {
-		hostHeader = "demo.localdev.me"
+		hostHeader = defaultHostHeader
 	}
 
 	// Verify expected output file exists for comparison.
@@ -181,10 +182,12 @@ func e2eTestSetup(t *testing.T, inputFile, outputFile string) (context.Context, 
 		t.Fatalf("gateway address: %v", err)
 	}
 
-	// Prefer HTTPRoute or TLSRoute hostnames if present.
+	// Prefer HTTPRoute or TLSRoute hostnames only when the input didn't specify any hosts.
 	host := hostHeader
-	if hr := testutils.FirstRouteHost(outObjs); hr != "" {
-		host = hr
+	if hostHeader == defaultHostHeader {
+		if hr := testutils.FirstRouteHost(outObjs); hr != "" {
+			host = hr
+		}
 	}
 
 	return ctx, gwAddr, host, hostHeader, ingressIP

--- a/test/e2e/emitters/common/config.go
+++ b/test/e2e/emitters/common/config.go
@@ -33,4 +33,6 @@ var (
 	KindClusterName = testutils.EnvOrDefault("KIND_CLUSTER_NAME", DefaultClusterName)
 	KeepCluster     = testutils.EnvOrDefault("KEEP_KIND_CLUSTER", "true") == "true"
 	KubeContext     = "kind-" + KindClusterName
+	// The host header to use for test requests. Must match in testdata input files.
+	DefaultHostHeader = "demo.localdev.me"
 )

--- a/test/e2e/emitters/kgateway/e2e_test.go
+++ b/test/e2e/emitters/kgateway/e2e_test.go
@@ -35,6 +35,7 @@ import (
 var (
 	e2eSetupComplete bool
 	kubeContext      string
+	DefaultHostHeader   = common.DefaultHostHeader
 )
 
 func TestMain(m *testing.M) {
@@ -131,7 +132,7 @@ func e2eTestSetup(t *testing.T, inputFile, outputFile string) (context.Context, 
 		}
 	}
 	if hostHeader == "" {
-		hostHeader = "demo.localdev.me"
+		hostHeader = DefaultHostHeader
 	}
 
 	// Verify expected output file exists for comparison.
@@ -185,10 +186,12 @@ func e2eTestSetup(t *testing.T, inputFile, outputFile string) (context.Context, 
 		t.Fatalf("gateway address: %v", err)
 	}
 
-	// Prefer HTTPRoute or TLSRoute hostnames if present.
+	// Prefer HTTPRoute or TLSRoute hostnames only when the input didn't specify any hosts.
 	host := hostHeader
-	if hr := testutils.FirstRouteHost(outObjs); hr != "" {
-		host = hr
+	if hostHeader == DefaultHostHeader {
+		if hr := testutils.FirstRouteHost(outObjs); hr != "" {
+			host = hr
+		}
 	}
 
 	return ctx, gwAddr, host, hostHeader, ingressIP


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind bug
/kind test

**What this PR does / why we need it**:

Only call `FirstRouteHost()` when the header in the test request is unset. This prevents inadvertently overriding the host header when test cases use a host header that differs from the default ("demo.localdev.me").

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #78 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
