### PR TITLE
Fixes CORS Feature in Agentgateway and Kgateway Emitters

### DIFF
--- a/pkg/i2gw/emitters/agentgateway/README.md
+++ b/pkg/i2gw/emitters/agentgateway/README.md
@@ -153,6 +153,30 @@ These are mapped into an `AgentgatewayPolicy` using agentgateway’s `Traffic.Co
 - Method values are normalized to upper-case and filtered to valid Gateway API HTTP methods (plus `*`); unknown values are ignored.
 - If `cors-max-age` is unset or non-positive, it is not projected.
 
+##### Upstream CORS header stripping
+
+When CORS is projected, the emitter also adds a Gateway API `ResponseHeaderModifier` filter to the generated `HTTPRoute`
+rules to remove common CORS response headers from the upstream/backend response:
+
+- `Access-Control-Allow-Origin`
+- `Access-Control-Allow-Methods`
+- `Access-Control-Allow-Headers`
+- `Access-Control-Expose-Headers`
+- `Access-Control-Max-Age`
+- `Access-Control-Allow-Credentials`
+
+**Why?**
+
+Some backends unconditionally emit permissive CORS headers (for example `Access-Control-Allow-Origin: *`), which can
+cause disallowed Origins to appear “allowed” even when the gateway policy is configured with a restricted allowlist.
+Stripping these upstream headers ensures that the effective CORS behavior is controlled by the emitted policy.
+
+**Impact:**
+
+If your application intentionally manages CORS by emitting its own CORS headers, enabling CORS on the Ingress and using
+the agentgateway emitter will suppress those upstream headers. Configure the desired CORS behavior via the Ingress NGINX
+CORS annotations so it is enforced by the gateway.
+
 #### Basic Authentication
 
 The agentgateway emitter supports projecting Basic Authentication from the following Ingress NGINX annotations:

--- a/pkg/i2gw/emitters/agentgateway/backend_tls.go
+++ b/pkg/i2gw/emitters/agentgateway/backend_tls.go
@@ -40,11 +40,11 @@ import (
 //   - TargetRefs are populated with each covered core Service backend (based on RuleBackendSources).
 //
 // Notes:
+//   - The ingress-nginx IR provides a single SecretName; we map this to mtlsCertificateRef when Verify=true.
 //   - Agentgateway backend TLS uses:
 //     - mtlsCertificateRef: Secret containing tls.crt/tls.key (and optional ca.cert)
 //     - caCertificateRefs: ConfigMap refs (not used here)
 //     - insecureSkipVerify: enum (All|Hostname)
-//   - The ingress-nginx IR provides a single SecretName; we map this to mtlsCertificateRef when Verify=true.
 func applyBackendTLSPolicy(
 	pol providerir.Policy,
 	httpRouteKey types.NamespacedName,

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/output/cors.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/output/cors.yaml
@@ -34,6 +34,16 @@ spec:
   - backendRefs:
     - name: myserviceb
       port: 80
+    filters:
+    - responseHeaderModifier:
+        remove:
+        - Access-Control-Allow-Origin
+        - Access-Control-Allow-Methods
+        - Access-Control-Allow-Headers
+        - Access-Control-Expose-Headers
+        - Access-Control-Max-Age
+        - Access-Control-Allow-Credentials
+      type: ResponseHeaderModifier
     matches:
     - path:
         type: PathPrefix
@@ -57,6 +67,16 @@ spec:
   - backendRefs:
     - name: myservicea
       port: 80
+    filters:
+    - responseHeaderModifier:
+        remove:
+        - Access-Control-Allow-Origin
+        - Access-Control-Allow-Methods
+        - Access-Control-Allow-Headers
+        - Access-Control-Expose-Headers
+        - Access-Control-Max-Age
+        - Access-Control-Allow-Credentials
+      type: ResponseHeaderModifier
     matches:
     - path:
         type: PathPrefix

--- a/pkg/i2gw/emitters/kgateway/testing/testdata/output/cors.yaml
+++ b/pkg/i2gw/emitters/kgateway/testing/testdata/output/cors.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   gatewayClassName: kgateway
   listeners:
-    - hostname: myservicea.foo.org
-      name: myservicea-foo-org-http
-      port: 80
-      protocol: HTTP
-    - hostname: myserviceb.foo.org
-      name: myserviceb-foo-org-http
-      port: 80
-      protocol: HTTP
+  - hostname: myservicea.foo.org
+    name: myservicea-foo-org-http
+    port: 80
+    protocol: HTTP
+  - hostname: myserviceb.foo.org
+    name: myserviceb-foo-org-http
+    port: 80
+    protocol: HTTP
 status: {}
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -27,36 +27,56 @@ metadata:
   namespace: default
 spec:
   hostnames:
-    - myservicea.foo.org
+  - myservicea.foo.org
   parentRefs:
-    - name: nginx
+  - name: nginx
   rules:
-    - backendRefs:
-        - filters:
-            - extensionRef:
-                group: gateway.kgateway.dev
-                kind: TrafficPolicy
-                name: ingress-myservicea1
-              type: ExtensionRef
-          name: myservicea
-          port: 80
-      matches:
-        - path:
-            type: PathPrefix
-            value: /
-    - backendRefs:
-        - filters:
-            - extensionRef:
-                group: gateway.kgateway.dev
-                kind: TrafficPolicy
-                name: ingress-myservicea2
-              type: ExtensionRef
-          name: myservicea
-          port: 80
-      matches:
-        - path:
-            type: PathPrefix
-            value: /2
+  - backendRefs:
+    - filters:
+      - extensionRef:
+          group: gateway.kgateway.dev
+          kind: TrafficPolicy
+          name: ingress-myservicea1
+        type: ExtensionRef
+      name: myservicea
+      port: 80
+    filters:
+    - responseHeaderModifier:
+        remove:
+        - Access-Control-Allow-Origin
+        - Access-Control-Allow-Methods
+        - Access-Control-Allow-Headers
+        - Access-Control-Expose-Headers
+        - Access-Control-Max-Age
+        - Access-Control-Allow-Credentials
+      type: ResponseHeaderModifier
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+  - backendRefs:
+    - filters:
+      - extensionRef:
+          group: gateway.kgateway.dev
+          kind: TrafficPolicy
+          name: ingress-myservicea2
+        type: ExtensionRef
+      name: myservicea
+      port: 80
+    filters:
+    - responseHeaderModifier:
+        remove:
+        - Access-Control-Allow-Origin
+        - Access-Control-Allow-Methods
+        - Access-Control-Allow-Headers
+        - Access-Control-Expose-Headers
+        - Access-Control-Max-Age
+        - Access-Control-Allow-Credentials
+      type: ResponseHeaderModifier
+    matches:
+    - path:
+        type: PathPrefix
+        value: /2
 status:
   parents: []
 ---
@@ -69,17 +89,27 @@ metadata:
   namespace: default
 spec:
   hostnames:
-    - myserviceb.foo.org
+  - myserviceb.foo.org
   parentRefs:
-    - name: nginx
+  - name: nginx
   rules:
-    - backendRefs:
-        - name: myserviceb
-          port: 80
-      matches:
-        - path:
-            type: PathPrefix
-            value: /
+  - backendRefs:
+    - name: myserviceb
+      port: 80
+    filters:
+    - responseHeaderModifier:
+        remove:
+        - Access-Control-Allow-Origin
+        - Access-Control-Allow-Methods
+        - Access-Control-Allow-Headers
+        - Access-Control-Expose-Headers
+        - Access-Control-Max-Age
+        - Access-Control-Allow-Credentials
+      type: ResponseHeaderModifier
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
 status:
   parents: []
 ---
@@ -92,18 +122,18 @@ spec:
   cors:
     allowCredentials: false
     allowHeaders:
-      - X-Requested-With
-      - Content-Type
+    - X-Requested-With
+    - Content-Type
     allowMethods:
-      - GET
-      - POST
-      - OPTIONS
+    - GET
+    - POST
+    - OPTIONS
     allowOrigins:
-      - https://example.com
-      - https://another.com
+    - https://example.com
+    - https://another.com
     exposeHeaders:
-      - X-Expose-One
-      - X-Expose-Two
+    - X-Expose-One
+    - X-Expose-Two
     maxAge: 600
 status:
   ancestors: null
@@ -116,8 +146,8 @@ metadata:
 spec:
   cors:
     allowOrigins:
-      - https://example.com
-      - https://another.com
+    - https://example.com
+    - https://another.com
 status:
   ancestors: null
 ---
@@ -129,14 +159,14 @@ metadata:
 spec:
   cors:
     allowOrigins:
-      - https://example.com
-      - https://another.com
+    - https://example.com
+    - https://another.com
     exposeHeaders:
-      - '*'
-      - X-CustomResponseHeader
+    - '*'
+    - X-CustomResponseHeader
   targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: ingress-myserviceb-myserviceb-foo-org
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ingress-myserviceb-myserviceb-foo-org
 status:
   ancestors: null

--- a/pkg/i2gw/emitters/utils/cors_headers.go
+++ b/pkg/i2gw/emitters/utils/cors_headers.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var corsResponseHeadersToStrip = []string{
+	"Access-Control-Allow-Origin",
+	"Access-Control-Allow-Methods",
+	"Access-Control-Allow-Headers",
+	"Access-Control-Expose-Headers",
+	"Access-Control-Max-Age",
+	"Access-Control-Allow-Credentials",
+}
+
+func EnsureStripUpstreamCORSHeaders(hr *gatewayv1.HTTPRoute) {
+	if hr == nil {
+		return
+	}
+	for i := range hr.Spec.Rules {
+		upsertStripUpstreamCORSHeaders(&hr.Spec.Rules[i])
+	}
+}
+
+// For partial coverage, e.g. kgateway, strip only for selected rules.
+func EnsureStripUpstreamCORSHeadersForRules(hr *gatewayv1.HTTPRoute, ruleIdxs map[int]struct{}) {
+	if hr == nil {
+		return
+	}
+	for i := range hr.Spec.Rules {
+		if _, ok := ruleIdxs[i]; !ok {
+			continue
+		}
+		upsertStripUpstreamCORSHeaders(&hr.Spec.Rules[i])
+	}
+}
+
+func upsertStripUpstreamCORSHeaders(rule *gatewayv1.HTTPRouteRule) {
+	for i := range rule.Filters {
+		f := &rule.Filters[i]
+		if f.Type != gatewayv1.HTTPRouteFilterResponseHeaderModifier {
+			continue
+		}
+		if f.ResponseHeaderModifier == nil {
+			f.ResponseHeaderModifier = &gatewayv1.HTTPHeaderFilter{}
+		}
+		seen := map[string]struct{}{}
+		for _, h := range f.ResponseHeaderModifier.Remove {
+			seen[strings.ToLower(h)] = struct{}{}
+		}
+		for _, h := range corsResponseHeadersToStrip {
+			if _, ok := seen[strings.ToLower(h)]; ok {
+				continue
+			}
+			f.ResponseHeaderModifier.Remove = append(f.ResponseHeaderModifier.Remove, h)
+		}
+		return
+	}
+
+	rule.Filters = append(rule.Filters, gatewayv1.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+		ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+			Remove: append([]string(nil), corsResponseHeadersToStrip...),
+		},
+	})
+}

--- a/test/e2e/emitters/agentgateway/testdata/output/cors.yaml
+++ b/test/e2e/emitters/agentgateway/testdata/output/cors.yaml
@@ -28,6 +28,16 @@ spec:
   - backendRefs:
     - name: echo-backend
       port: 8080
+    filters:
+    - responseHeaderModifier:
+        remove:
+        - Access-Control-Allow-Origin
+        - Access-Control-Allow-Methods
+        - Access-Control-Allow-Headers
+        - Access-Control-Expose-Headers
+        - Access-Control-Max-Age
+        - Access-Control-Allow-Credentials
+      type: ResponseHeaderModifier
     matches:
     - path:
         type: PathPrefix

--- a/test/e2e/emitters/kgateway/e2e_test.go
+++ b/test/e2e/emitters/kgateway/e2e_test.go
@@ -326,6 +326,51 @@ func TestCORS(t *testing.T) {
 		ExpectedStatusCode: 200,
 		Timeout:            1 * time.Minute,
 	})
+
+	// Negative coverage:
+	// - ensure upstream CORS headers are stripped
+	// - ensure only configured allowOrigins are reflected back
+	//
+	// We force the upstream echo backend to emit a permissive ACAO header using
+	// X-Echo-Set-Header (echo server feature) and then assert the gateway behavior.
+	base := testutils.HTTPRequestConfig{
+		Scheme:              "http",
+		Address:             gwAddr,
+		HostHeader:          "cors.localdev.me",
+		Port:                "80",
+		Path:                "/get",
+		ExpectedStatusCodes: []int{200},
+		Timeout:             time.Minute,
+	}
+
+	// No Origin header: should NOT emit ACAO (and should strip upstream ACAO).
+	{
+		cfg := base
+		cfg.Headers = map[string]string{
+			"X-Echo-Set-Header": "Access-Control-Allow-Origin:*",
+		}
+		testutils.RequireResponseHeaderEventually(t, cfg, "Access-Control-Allow-Origin", false, "")
+	}
+
+	// Disallowed Origin: should NOT emit ACAO (and should strip upstream ACAO).
+	{
+		cfg := base
+		cfg.Headers = map[string]string{
+			"Origin":            "https://evil.com",
+			"X-Echo-Set-Header": "Access-Control-Allow-Origin:*",
+		}
+		testutils.RequireResponseHeaderEventually(t, cfg, "Access-Control-Allow-Origin", false, "")
+	}
+
+	// Allowed Origin: should emit ACAO:<origin> (and must NOT leak upstream '*').
+	{
+		cfg := base
+		cfg.Headers = map[string]string{
+			"Origin":            "https://example.com",
+			"X-Echo-Set-Header": "Access-Control-Allow-Origin:*",
+		}
+		testutils.RequireResponseHeaderEventually(t, cfg, "Access-Control-Allow-Origin", true, "https://example.com")
+	}
 }
 
 func TestRewriteTarget(t *testing.T) {

--- a/test/e2e/emitters/kgateway/testdata/output/cors.yaml
+++ b/test/e2e/emitters/kgateway/testdata/output/cors.yaml
@@ -1,9 +1,9 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: nginx
   annotations:
     gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
 spec:
   gatewayClassName: kgateway
   listeners:
@@ -16,22 +16,32 @@ status: {}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ingress-cors-b-cors-localdev-me
   annotations:
     gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: ingress-cors-b-cors-localdev-me
 spec:
   hostnames:
   - cors.localdev.me
   parentRefs:
   - name: nginx
   rules:
-  - matches:
+  - backendRefs:
+    - name: echo-backend
+      port: 8080
+    filters:
+    - responseHeaderModifier:
+        remove:
+        - Access-Control-Allow-Origin
+        - Access-Control-Allow-Methods
+        - Access-Control-Allow-Headers
+        - Access-Control-Expose-Headers
+        - Access-Control-Max-Age
+        - Access-Control-Allow-Credentials
+      type: ResponseHeaderModifier
+    matches:
     - path:
         type: PathPrefix
         value: /
-    backendRefs:
-    - name: echo-backend
-      port: 8080
 status:
   parents: []
 ---
@@ -45,7 +55,7 @@ spec:
     - https://example.com
     - https://another.com
     exposeHeaders:
-    - "*"
+    - '*'
     - X-CustomResponseHeader
   targetRefs:
   - group: gateway.networking.k8s.io


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Correct the ingress-nginx -> agentgateway and kgateway policy mapping for CORS (parsing, de-dupe/normalization, etc).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
