### PR TITLE
test(e2e): add agentgateway load balance coverage

### DIFF
--- a/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
+++ b/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
@@ -207,6 +207,32 @@ func TestAgentgatewayIngressNginxIntegration_RateLimit(t *testing.T) {
 	}
 }
 
+func TestAgentgatewayIngressNginxIntegration_LoadBalance(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name      string
+		inputRel  string
+		goldenRel string
+	}{
+		{
+			name: "load_balance",
+			inputRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "input", "load_balance.yaml",
+			),
+			goldenRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "output", "load_balance.yaml",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runGoldenTest(t, tt.inputRel, tt.goldenRel)
+		})
+	}
+}
+
 func TestAgentgatewayIngressNginxIntegration_BasicAuth(t *testing.T) {
 	t.Helper()
 

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/input/load_balance.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/input/load_balance.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/load-balance: "round_robin"
+  name: lb-localhost
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: lb.localdev.me
+    http:
+      paths:
+      - backend:
+          service:
+            name: echo-backend
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/output/load_balance.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/output/load_balance.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - hostname: lb.localdev.me
+    name: lb-localdev-me-http
+    port: 80
+    protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: lb-localhost-lb-localdev-me
+  namespace: default
+spec:
+  hostnames:
+  - lb.localdev.me
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: echo-backend
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []

--- a/test/e2e/emitters/agentgateway/testdata/input/load_balance.yaml
+++ b/test/e2e/emitters/agentgateway/testdata/input/load_balance.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/load-balance: "round_robin"
+  name: lb-localhost
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: lb.localdev.me
+    http:
+      paths:
+      - backend:
+          service:
+            name: echo-backend
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/test/e2e/emitters/agentgateway/testdata/output/load_balance.yaml
+++ b/test/e2e/emitters/agentgateway/testdata/output/load_balance.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - hostname: lb.localdev.me
+    name: lb-localdev-me-http
+    port: 80
+    protocol: HTTP
+status: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: lb-localhost-lb-localdev-me
+  namespace: default
+spec:
+  hostnames:
+  - lb.localdev.me
+  parentRefs:
+  - name: nginx
+  rules:
+  - backendRefs:
+    - name: echo-backend
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents: []


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/CONTRIBUTING.md). -->

<!-- The release notes and the kind will be used to generate the Changelog for the release. To make sure your contribution is recognized, please label this pull request according to what type of issue you are addressing and add the release notes when necessary (see ../CONTRIBUTING.md) -->

**What type of PR is this?**

/kind test

**What this PR does / why we need it**:
Adds agentgateway load balance coverage:
- Adds golden test + input/output fixtures under `pkg/i2gw/emitters/agentgateway/...`
- Adds e2e test + input/output fixtures under `test/e2e/emitters/agentgateway/...`

[e2e test log gist](https://gist.github.com/ShaanveerS/0b0c67d006ce395bc9ac31ddacf22d42)

**Which issue(s) this PR fixes**:
Part of #82 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
