### PR TITLE
agentgateway: target partial traffic policies by rule

### DIFF
--- a/pkg/i2gw/emitters/agentgateway/README.md
+++ b/pkg/i2gw/emitters/agentgateway/README.md
@@ -192,6 +192,8 @@ This is mapped into `AgentgatewayPolicy.spec.frontend.accessLog`:
 
 - ingress-nginx enables access logs by default when this annotation is absent.
 - The emitter only projects access-log behavior when the annotation is explicitly present on the source Ingress.
+- If the source Ingress contributes only some rules of a merged `HTTPRoute`, the emitter currently skips access-log
+  projection and emits a warning. Agentgateway frontend policies cannot target individual `HTTPRoute` rules.
 
 #### Basic Authentication
 
@@ -439,6 +441,8 @@ These are projected into an `AgentgatewayPolicy` by setting:
 - `proxy-body-size` is preferred when both annotations are present.
 - `client-body-buffer-size` is used as a fallback when `proxy-body-size` is unset.
 - The selected quantity is resolved to bytes for `maxBufferSize`.
+- If the source Ingress contributes only some rules of a merged `HTTPRoute`, the emitter currently skips this
+  projection and emits a warning. Agentgateway frontend policies cannot target individual `HTTPRoute` rules.
 
 #### Service Upstream
 
@@ -469,11 +473,13 @@ Mappings:
 
 ## AgentgatewayPolicy Projection
 
-Rate limit, timeout, CORS, rewrite target, access log, etc. annotations are converted into AgentgatewayPolicy resources.
-The agentgateway emitter emits AgentgatewayPolicy resources in two shapes:
+Rate limit, timeout, CORS, rewrite target, access log, etc. annotations are converted into `AgentgatewayPolicy`
+resources. The agentgateway emitter emits `AgentgatewayPolicy` resources in three shapes:
 
-- HTTPRoute-scoped policies for traffic-level behavior (rate limit, request timeouts, CORS, rewrite target,
-  basic auth, ext auth, access log, request/body buffer size).
+- Route- or rule-scoped traffic policies for traffic-level behavior (rate limit, request timeouts, CORS, rewrite
+  target, basic auth, ext auth).
+- HTTPRoute-wide frontend policies for frontend behavior (access log, request/body buffer size) when the source
+  Ingress effectively covers the whole generated route.
 - Service-scoped policies for backend connection behavior (backend TLS, proxy connect timeout, backend protocol).
 
 ### Naming
@@ -500,29 +506,46 @@ Backend protocol policies are created **per targeted backend object**:
 
 ### Attachment Semantics
 
-If a policy covers all backends of the generated HTTPRoute, the policy is attached using `spec.targetRefs`
-to the HTTPRoute.
+Traffic policies are attached as precisely as Agentgateway allows:
 
-If a policy only covers some (rule, backendRef) pairs, the emitter **returns an error** and does not emit
-+agentgateway resources for that Ingress.
+- If a policy covers all backends of the generated `HTTPRoute`, the emitter attaches it to the `HTTPRoute`.
+- If a policy covers all backends of one or more specific `HTTPRoute` rules, the emitter attaches it to those rules
+  using `spec.targetRefs[].sectionName`.
+- If a policy covers only some backendRefs within a single `HTTPRoute` rule, the emitter **returns an error** and does
+  not emit that `AgentgatewayPolicy`.
+
+Frontend policies are more restrictive:
+
+- Frontend policy fields such as `spec.frontend.accessLog` and `spec.frontend.http.maxBufferSize` can only be emitted
+  when they can target the whole generated route.
+- If those annotations appear on an Ingress that contributes only some rules of a merged `HTTPRoute`, the emitter skips
+  the frontend projection and emits a warning instead of failing the entire conversion.
 
 Conceptually:
 
-- **Full coverage** → `AgentgatewayPolicy.spec.targetRefs[]` references the HTTPRoute
-- **Partial coverage** → **error** (agentgateway does not support attaching `AgentgatewayPolicy` via per-backend
-  `HTTPRoute` `ExtensionRef` filters)
+- **Whole-route coverage** → `AgentgatewayPolicy.spec.targetRefs[]` references the `HTTPRoute`
+- **Whole-rule coverage** → `AgentgatewayPolicy.spec.targetRefs[]` references the `HTTPRoute` with
+  `sectionName: <rule-name>`
+- **Partial backend coverage within one rule** → **error**
+- **Partial merged-route frontend coverage** → skipped with warning
 
 #### Why?
 
 Agentgateway does not support `HTTPRoute` `backendRefs[].filters[].type: ExtensionRef` for attaching policies.
 Attempting to generate per-backend `ExtensionRef` filters results in `HTTPRoute` status failures (e.g.
-`ResolvedRefs=False` with an `IncompatibleFilters` error). To avoid emitting manifests that will be rejected or
-non-functional at runtime, the emitter fails fast during generation when only partial attachment is possible.
+`ResolvedRefs=False` with an `IncompatibleFilters` error). Agentgateway does, however, support targeting an
+`HTTPRoute` rule by `targetRefs[].sectionName`, so the emitter uses rule-scoped attachment whenever a policy cleanly
+applies to complete rules. The remaining failure case is when only some backendRefs within one rule are covered,
+because that would still require per-backend attachment. Frontend policy fields remain route-wide only, so partial
+merged-route frontend projection is skipped.
 
 #### Workarounds
 
-- Split the source Ingress into separate Ingress resources so each generated HTTPRoute can be fully covered by a policy.
-- Adjust annotations so the policy applies uniformly to all paths/backends of the resulting HTTPRoute.
+- Split the source Ingress into separate Ingress resources so each generated `HTTPRoute` rule or route can be covered
+  cleanly.
+- Adjust annotations so a traffic policy applies uniformly to complete rules of the resulting `HTTPRoute`.
+- For frontend behavior on merged routes, either apply the annotation uniformly across the merged route or split the
+  source Ingress resources so the frontend policy can target a whole route.
 
 For backend TLS, prefer targeting the **Service** via a backend policy (as emitted) so TLS settings apply cleanly without
 needing per-backend HTTPRoute filters.

--- a/pkg/i2gw/emitters/agentgateway/agentgateway.go
+++ b/pkg/i2gw/emitters/agentgateway/agentgateway.go
@@ -120,17 +120,18 @@ func (e *Emitter) ToAgentgatewayResources(
 			// generating duplicate filters on the same backendRef.
 			coverage := uniquePolicyIndices(pol.RuleBackendSources)
 
-			touched := false
+			trafficTouched := false
+			frontendTouched := false
 			corsTouched := false
 
 			// Apply rate limit policy features that map to AgentgatewayPolicy.
 			if applyRateLimitPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
-				touched = true
+				trafficTouched = true
 			}
 
 			// Apply timeout policy features that map to AgentgatewayPolicy.
 			if applyRequestTimeoutPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
-				touched = true
+				trafficTouched = true
 			}
 
 			// Check if SSL redirect is enabled but don't apply it yet (will split route later).
@@ -149,25 +150,24 @@ func (e *Emitter) ToAgentgatewayResources(
 			)
 
 			// rewrite-target maps to AgentgatewayPolicy.spec.traffic.transformation.
-			// Note: agentgateway attaches policies at the HTTPRoute scope; this feature is only safe when
-			// it fully covers the route (enforced by the full-coverage check below).
+			// Note: agentgateway can target either the whole HTTPRoute or specific rules via targetRefs.sectionName.
 			if applyRewriteTargetPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, &httpRouteContext, agentgatewayPolicies) {
-				touched = true
+				trafficTouched = true
 			}
 
 			// CORS maps to AgentgatewayPolicy.spec.traffic.cors.
 			if applyCorsPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
-				touched, corsTouched = true, true
+				trafficTouched, corsTouched = true, true
 			}
 
 			// enable-access-log maps to AgentgatewayPolicy.spec.frontend.accessLog.
 			if applyAccessLogPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
-				touched = true
+				frontendTouched = true
 			}
 
 			// ExtAuth maps to AgentgatewayPolicy.spec.traffic.extAuth.
 			if applyExtAuthPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
-				touched = true
+				trafficTouched = true
 			}
 
 			// Backend TLS maps to AgentgatewayPolicy.spec.backend.tls, targeting the covered Service backends.
@@ -202,7 +202,7 @@ func (e *Emitter) ToAgentgatewayResources(
 			// BasicAuth maps to AgentgatewayPolicy.spec.traffic.basicAuthentication.
 			// Note: agentgateway expects htpasswd content under a '.htaccess' key; see BasicAuthentication docs.
 			if applyBasicAuthPolicy(pol, polSourceIngressName, httpRouteKey.Namespace, agentgatewayPolicies) {
-				touched = true
+				trafficTouched = true
 				// Emit an INFO notification with guidance about Secret key expectations.
 				emitBasicAuthSecretNotifications(
 					e.notify,
@@ -222,46 +222,92 @@ func (e *Emitter) ToAgentgatewayResources(
 			); bufferErr != nil {
 				errs = append(errs, bufferErr)
 			} else if bufferTouched {
-				touched = true
+				frontendTouched = true
 			}
 
-			// Attach the resulting AgentgatewayPolicy to the HTTPRoute, but only if the policy fully covers the route.
-			// Unlike kgateway, agentgateway does not support attaching policies via HTTPRoute filter ExtensionRef.
-			if touched {
-				agp := agentgatewayPolicies[polSourceIngressName]
-				if agp != nil {
-					total := numRules(httpRouteContext.HTTPRoute)
-					covered := len(coverage)
-					// Some ingress-nginx features are recorded at the Ingress scope (not per rule/backend pair).
-					// In that case RuleBackendSources may be empty; treat this as "applies to all backends".
-					// This avoids false "subset coverage" errors like (0/1) for Ingress-wide annotations.
-					if covered == 0 {
-						covered = total
-					}
+			if !trafficTouched && !frontendTouched {
+				continue
+			}
 
-					if covered == total {
-						agp.Spec.TargetRefs = []shared.LocalPolicyTargetReferenceWithSectionName{{
-							LocalPolicyTargetReference: shared.LocalPolicyTargetReference{
-								Group: gatewayv1.Group("gateway.networking.k8s.io"),
-								Kind:  gatewayv1.Kind("HTTPRoute"),
-								Name:  gatewayv1.ObjectName(httpRouteKey.Name),
-							},
-						}}
-						// Strip upstream CORS headers when CORS is enabled and policy is attached.
-						if corsTouched {
-							utils.EnsureStripUpstreamCORSHeaders(&httpRouteContext.HTTPRoute)
-						}
-					} else {
-						errs = append(errs, field.Invalid(
-							field.NewPath("emitter", "agentgateway", "AgentgatewayPolicy"),
+			agp := agentgatewayPolicies[polSourceIngressName]
+			if agp == nil {
+				continue
+			}
+
+			if frontendTouched && trafficTouched {
+				attachment, attachErr := buildTrafficPolicyAttachment(httpRouteKey, httpRouteContext, coverage, polSourceIngressName)
+				if attachErr != nil {
+					errs = append(errs, attachErr)
+					delete(agentgatewayPolicies, polSourceIngressName)
+					continue
+				}
+
+				// Frontend-scoped settings cannot target individual HTTPRoute rules. If the traffic policy needs
+				// sectionName attachments, drop the frontend projection so the valid traffic policy can still be emitted.
+				if len(attachment.TargetRefs) != 1 || attachment.TargetRefs[0].SectionName != nil {
+					e.notify(
+						notifications.WarningNotification,
+						fmt.Sprintf(
+							"Skipping frontend-scoped policy projection for Ingress %s: agentgateway frontend policies cannot target individual HTTPRoute rules within merged routes",
 							polSourceIngressName,
-							fmt.Sprintf("policy only applies to a subset of backendRefs within the HTTPRoute (%d/%d); "+
-								"agentgateway requires full policy coverage because it does not support attaching policies "+
-								"via HTTPRoute filter ExtensionRef", covered, total),
-						))
-						delete(agentgatewayPolicies, polSourceIngressName)
+						),
+						&httpRouteContext.HTTPRoute,
+					)
+					agp.Spec.Frontend = nil
+					frontendTouched = false
+				}
+
+				agp.Spec.TargetRefs = attachment.TargetRefs
+				if corsTouched {
+					if len(attachment.TargetRefs) == 1 && attachment.TargetRefs[0].SectionName == nil {
+						utils.EnsureStripUpstreamCORSHeaders(&httpRouteContext.HTTPRoute)
+					} else {
+						utils.EnsureStripUpstreamCORSHeadersForRules(&httpRouteContext.HTTPRoute, attachment.CoveredRuleIdxs)
 					}
 				}
+				continue
+			}
+
+			if trafficTouched {
+				attachment, attachErr := buildTrafficPolicyAttachment(httpRouteKey, httpRouteContext, coverage, polSourceIngressName)
+				if attachErr != nil {
+					errs = append(errs, attachErr)
+					delete(agentgatewayPolicies, polSourceIngressName)
+					continue
+				}
+
+				agp.Spec.TargetRefs = attachment.TargetRefs
+				if corsTouched {
+					if len(attachment.TargetRefs) == 1 && attachment.TargetRefs[0].SectionName == nil {
+						utils.EnsureStripUpstreamCORSHeaders(&httpRouteContext.HTTPRoute)
+					} else {
+						utils.EnsureStripUpstreamCORSHeadersForRules(&httpRouteContext.HTTPRoute, attachment.CoveredRuleIdxs)
+					}
+				}
+				continue
+			}
+
+			if frontendTouched {
+				if !hasFullBackendCoverage(httpRouteContext.HTTPRoute, coverage) {
+					e.notify(
+						notifications.WarningNotification,
+						fmt.Sprintf(
+							"Skipping frontend-scoped policy projection for Ingress %s: agentgateway frontend policies cannot target only part of a merged HTTPRoute",
+							polSourceIngressName,
+						),
+						&httpRouteContext.HTTPRoute,
+					)
+					delete(agentgatewayPolicies, polSourceIngressName)
+					continue
+				}
+
+				agp.Spec.TargetRefs = []shared.LocalPolicyTargetReferenceWithSectionName{{
+					LocalPolicyTargetReference: shared.LocalPolicyTargetReference{
+						Group: gatewayv1.Group("gateway.networking.k8s.io"),
+						Kind:  gatewayv1.Kind("HTTPRoute"),
+						Name:  gatewayv1.ObjectName(httpRouteKey.Name),
+					},
+				}}
 			}
 		}
 

--- a/pkg/i2gw/emitters/agentgateway/attachment.go
+++ b/pkg/i2gw/emitters/agentgateway/attachment.go
@@ -76,10 +76,10 @@ func buildTrafficPolicyAttachment(
 			}
 		}
 
-		switch {
-		case validCoveredBackends == 0:
+		switch validCoveredBackends {
+		case 0:
 			continue
-		case validCoveredBackends == backendCount:
+		case backendCount:
 			attachment.CoveredRuleIdxs[ruleIdx] = struct{}{}
 		default:
 			ruleName := ruleSectionName(rule, ruleIdx)

--- a/pkg/i2gw/emitters/agentgateway/attachment.go
+++ b/pkg/i2gw/emitters/agentgateway/attachment.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentgateway
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/shared"
+	emitterir "github.com/kgateway-dev/ingress2gateway/pkg/i2gw/emitter_intermediate"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type trafficPolicyAttachment struct {
+	TargetRefs      []shared.LocalPolicyTargetReferenceWithSectionName
+	CoveredRuleIdxs map[int]struct{}
+}
+
+func buildTrafficPolicyAttachment(
+	httpRouteKey types.NamespacedName,
+	httpRouteCtx emitterir.HTTPRouteContext,
+	coverage []emitterir.PolicyIndex,
+	policyName string,
+) (trafficPolicyAttachment, *field.Error) {
+	attachment := trafficPolicyAttachment{
+		CoveredRuleIdxs: map[int]struct{}{},
+	}
+
+	if len(httpRouteCtx.Spec.Rules) == 0 || len(coverage) == 0 {
+		attachment.TargetRefs = []shared.LocalPolicyTargetReferenceWithSectionName{
+			httpRouteTargetRef(httpRouteKey.Name, nil),
+		}
+		return attachment, nil
+	}
+
+	coveredByRule := make(map[int]map[int]struct{}, len(httpRouteCtx.Spec.Rules))
+	for _, idx := range coverage {
+		if idx.Rule < 0 || idx.Rule >= len(httpRouteCtx.Spec.Rules) || idx.Backend < 0 {
+			continue
+		}
+		if _, ok := coveredByRule[idx.Rule]; !ok {
+			coveredByRule[idx.Rule] = map[int]struct{}{}
+		}
+		coveredByRule[idx.Rule][idx.Backend] = struct{}{}
+	}
+
+	for ruleIdx, rule := range httpRouteCtx.Spec.Rules {
+		backendCount := len(rule.BackendRefs)
+		if backendCount == 0 {
+			continue
+		}
+
+		validCoveredBackends := 0
+		if backends, ok := coveredByRule[ruleIdx]; ok {
+			for backendIdx := range backends {
+				if backendIdx >= backendCount {
+					continue
+				}
+				validCoveredBackends++
+			}
+		}
+
+		switch {
+		case validCoveredBackends == 0:
+			continue
+		case validCoveredBackends == backendCount:
+			attachment.CoveredRuleIdxs[ruleIdx] = struct{}{}
+		default:
+			ruleName := ruleSectionName(rule, ruleIdx)
+			return trafficPolicyAttachment{}, field.Invalid(
+				field.NewPath("emitter", "agentgateway", "AgentgatewayPolicy"),
+				policyName,
+				fmt.Sprintf(
+					"policy only applies to a subset of backendRefs within HTTPRoute rule %q (%d/%d); agentgateway can target whole HTTPRoute rules via targetRefs.sectionName, but cannot attach traffic policy to only some backendRefs within a rule",
+					ruleName,
+					validCoveredBackends,
+					backendCount,
+				),
+			)
+		}
+	}
+
+	if len(attachment.CoveredRuleIdxs) == 0 {
+		return trafficPolicyAttachment{}, field.Invalid(
+			field.NewPath("emitter", "agentgateway", "AgentgatewayPolicy"),
+			policyName,
+			"policy did not resolve to any covered HTTPRoute rules",
+		)
+	}
+
+	if len(attachment.CoveredRuleIdxs) == len(httpRouteCtx.Spec.Rules) {
+		attachment.TargetRefs = []shared.LocalPolicyTargetReferenceWithSectionName{
+			httpRouteTargetRef(httpRouteKey.Name, nil),
+		}
+		return attachment, nil
+	}
+
+	ruleIdxs := make([]int, 0, len(attachment.CoveredRuleIdxs))
+	for ruleIdx := range attachment.CoveredRuleIdxs {
+		ruleIdxs = append(ruleIdxs, ruleIdx)
+	}
+	sort.Ints(ruleIdxs)
+
+	attachment.TargetRefs = make([]shared.LocalPolicyTargetReferenceWithSectionName, 0, len(ruleIdxs))
+	for _, ruleIdx := range ruleIdxs {
+		sectionName := ruleSectionName(httpRouteCtx.Spec.Rules[ruleIdx], ruleIdx)
+		attachment.TargetRefs = append(
+			attachment.TargetRefs,
+			httpRouteTargetRef(httpRouteKey.Name, &sectionName),
+		)
+	}
+
+	return attachment, nil
+}
+
+func hasFullBackendCoverage(httpRoute gatewayv1.HTTPRoute, coverage []emitterir.PolicyIndex) bool {
+	total := numRules(httpRoute)
+	if total == 0 || len(coverage) == 0 {
+		return true
+	}
+
+	validCovered := 0
+	for _, idx := range coverage {
+		if idx.Rule < 0 || idx.Rule >= len(httpRoute.Spec.Rules) {
+			continue
+		}
+		if idx.Backend < 0 || idx.Backend >= len(httpRoute.Spec.Rules[idx.Rule].BackendRefs) {
+			continue
+		}
+		validCovered++
+	}
+
+	return validCovered == total
+}
+
+func httpRouteTargetRef(
+	routeName string,
+	sectionName *gatewayv1.SectionName,
+) shared.LocalPolicyTargetReferenceWithSectionName {
+	return shared.LocalPolicyTargetReferenceWithSectionName{
+		LocalPolicyTargetReference: shared.LocalPolicyTargetReference{
+			Group: gatewayv1.Group("gateway.networking.k8s.io"),
+			Kind:  gatewayv1.Kind("HTTPRoute"),
+			Name:  gatewayv1.ObjectName(routeName),
+		},
+		SectionName: sectionName,
+	}
+}
+
+func ruleSectionName(rule gatewayv1.HTTPRouteRule, ruleIdx int) gatewayv1.SectionName {
+	if rule.Name != nil && *rule.Name != "" {
+		return *rule.Name
+	}
+	return gatewayv1.SectionName(fmt.Sprintf("rule-%d", ruleIdx))
+}

--- a/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
+++ b/pkg/i2gw/emitters/agentgateway/emitter_integration_test.go
@@ -521,3 +521,29 @@ func TestAgentgatewayIngressNginxIntegration_ServiceUpstream(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentgatewayIngressNginxIntegration_Issue110(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name      string
+		inputRel  string
+		goldenRel string
+	}{
+		{
+			name: "issue_110_partial_policy_rule_targets",
+			inputRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "input", "issue_110.yaml",
+			),
+			goldenRel: filepath.Join(
+				"pkg", "i2gw", "emitters", "agentgateway", "testing", "testdata", "output", "issue_110.yaml",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runGoldenTest(t, tt.inputRel, tt.goldenRel)
+		})
+	}
+}

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/input/issue_110.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/input/issue_110.yaml
@@ -1,0 +1,112 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: llm-scads-ai-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: tud-acme
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: 16m
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "180"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - llm.scads.ai
+    secretName: llm.scads.ai-acme
+  rules:
+  - host: llm.scads.ai
+    http:
+      paths:
+      - path: /metrics/?
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: blocked-service
+            port:
+              number: 80
+      - path: /auth
+        pathType: Prefix
+        backend:
+          service:
+            name: keycloak
+            port:
+              number: 80
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: llm-scads-ai-service
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: llm-scads-ai-documentation-redirect-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: tud-acme
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/permanent-redirect: /docs/
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: llm.scads.ai
+    http:
+      paths:
+      - path: /$
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: documentation-service
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: llm-scads-ai-documentation-rewrite-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: tud-acme
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: $1
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: llm.scads.ai
+    http:
+      paths:
+      - path: /docs(.*)$
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: documentation-service
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: llm-scads-ai-health-rewrite-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: tud-acme
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: $1
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: llm.scads.ai
+    http:
+      paths:
+      - path: /status(.*)$
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: api-state-service
+            port:
+              number: 80

--- a/pkg/i2gw/emitters/agentgateway/testing/testdata/output/issue_110.yaml
+++ b/pkg/i2gw/emitters/agentgateway/testing/testdata/output/issue_110.yaml
@@ -1,0 +1,378 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: llm-scads-ai-health-rewrite-ingress
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: llm-scads-ai-documentation-redirect-ingress-llm-scads-ai
+      sectionName: rule-2
+  traffic:
+    cors:
+      allowCredentials: true
+      allowHeaders:
+        - DNT
+        - Keep-Alive
+        - User-Agent
+        - X-Requested-With
+        - If-Modified-Since
+        - Cache-Control
+        - Content-Type
+        - Range
+        - Authorization
+      allowMethods:
+        - GET
+        - PUT
+        - POST
+        - DELETE
+        - PATCH
+        - OPTIONS
+      allowOrigins:
+        - '*'
+      maxAge: 1728000
+status:
+  ancestors: null
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: llm-scads-ai-ingress
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: llm-scads-ai-documentation-redirect-ingress-llm-scads-ai
+      sectionName: rule-3
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: llm-scads-ai-documentation-redirect-ingress-llm-scads-ai
+      sectionName: rule-4
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: llm-scads-ai-documentation-redirect-ingress-llm-scads-ai
+      sectionName: rule-5
+  traffic:
+    cors:
+      allowCredentials: true
+      allowHeaders:
+        - DNT
+        - Keep-Alive
+        - User-Agent
+        - X-Requested-With
+        - If-Modified-Since
+        - Cache-Control
+        - Content-Type
+        - Range
+        - Authorization
+      allowMethods:
+        - GET
+        - PUT
+        - POST
+        - DELETE
+        - PATCH
+        - OPTIONS
+      allowOrigins:
+        - '*'
+      maxAge: 1728000
+status:
+  ancestors: null
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: nginx
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - hostname: llm.scads.ai
+      name: llm-scads-ai-http
+      port: 80
+      protocol: HTTP
+    - hostname: llm.scads.ai
+      name: llm-scads-ai-https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: llm.scads.ai-acme
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: llm-scads-ai-documentation-redirect-ingress-llm-scads-ai
+spec:
+  hostnames:
+    - llm.scads.ai
+  parentRefs:
+    - name: nginx
+      port: 443
+  rules:
+    - filters:
+        - requestRedirect:
+            path:
+              replaceFullPath: /docs/
+              type: ReplaceFullPath
+            statusCode: 301
+          type: RequestRedirect
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/$.*
+      name: rule-0
+    - backendRefs:
+        - name: documentation-service
+          port: 80
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/docs(.*)$.*
+      name: rule-1
+    - backendRefs:
+        - name: api-state-service
+          port: 80
+      filters:
+        - cors:
+            allowCredentials: true
+            allowHeaders:
+              - DNT
+              - Keep-Alive
+              - User-Agent
+              - X-Requested-With
+              - If-Modified-Since
+              - Cache-Control
+              - Content-Type
+              - Range
+              - Authorization
+            allowMethods:
+              - GET
+              - PUT
+              - POST
+              - DELETE
+              - PATCH
+              - OPTIONS
+            allowOrigins:
+              - '*'
+            maxAge: 1728000
+          type: CORS
+        - responseHeaderModifier:
+            remove:
+              - Access-Control-Allow-Origin
+              - Access-Control-Allow-Methods
+              - Access-Control-Allow-Headers
+              - Access-Control-Expose-Headers
+              - Access-Control-Max-Age
+              - Access-Control-Allow-Credentials
+          type: ResponseHeaderModifier
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/status(.*)$.*
+      name: rule-2
+    - backendRefs:
+        - name: blocked-service
+          port: 80
+      filters:
+        - cors:
+            allowCredentials: true
+            allowHeaders:
+              - DNT
+              - Keep-Alive
+              - User-Agent
+              - X-Requested-With
+              - If-Modified-Since
+              - Cache-Control
+              - Content-Type
+              - Range
+              - Authorization
+            allowMethods:
+              - GET
+              - PUT
+              - POST
+              - DELETE
+              - PATCH
+              - OPTIONS
+            allowOrigins:
+              - '*'
+            maxAge: 1728000
+          type: CORS
+        - responseHeaderModifier:
+            remove:
+              - Access-Control-Allow-Origin
+              - Access-Control-Allow-Methods
+              - Access-Control-Allow-Headers
+              - Access-Control-Expose-Headers
+              - Access-Control-Max-Age
+              - Access-Control-Allow-Credentials
+          type: ResponseHeaderModifier
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/metrics/?.*
+      name: rule-3
+      timeouts:
+        request: 1h40m0s
+    - backendRefs:
+        - name: keycloak
+          port: 80
+      filters:
+        - cors:
+            allowCredentials: true
+            allowHeaders:
+              - DNT
+              - Keep-Alive
+              - User-Agent
+              - X-Requested-With
+              - If-Modified-Since
+              - Cache-Control
+              - Content-Type
+              - Range
+              - Authorization
+            allowMethods:
+              - GET
+              - PUT
+              - POST
+              - DELETE
+              - PATCH
+              - OPTIONS
+            allowOrigins:
+              - '*'
+            maxAge: 1728000
+          type: CORS
+        - responseHeaderModifier:
+            remove:
+              - Access-Control-Allow-Origin
+              - Access-Control-Allow-Methods
+              - Access-Control-Allow-Headers
+              - Access-Control-Expose-Headers
+              - Access-Control-Max-Age
+              - Access-Control-Allow-Credentials
+          type: ResponseHeaderModifier
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/auth.*
+      name: rule-4
+      timeouts:
+        request: 1h40m0s
+    - backendRefs:
+        - name: llm-scads-ai-service
+          port: 80
+      filters:
+        - cors:
+            allowCredentials: true
+            allowHeaders:
+              - DNT
+              - Keep-Alive
+              - User-Agent
+              - X-Requested-With
+              - If-Modified-Since
+              - Cache-Control
+              - Content-Type
+              - Range
+              - Authorization
+            allowMethods:
+              - GET
+              - PUT
+              - POST
+              - DELETE
+              - PATCH
+              - OPTIONS
+            allowOrigins:
+              - '*'
+            maxAge: 1728000
+          type: CORS
+        - responseHeaderModifier:
+            remove:
+              - Access-Control-Allow-Origin
+              - Access-Control-Allow-Methods
+              - Access-Control-Allow-Headers
+              - Access-Control-Expose-Headers
+              - Access-Control-Max-Age
+              - Access-Control-Allow-Credentials
+          type: ResponseHeaderModifier
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/.*
+      name: rule-5
+      timeouts:
+        request: 1h40m0s
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gateway.networking.k8s.io/generator: ingress2gateway-dev
+  name: llm-scads-ai-documentation-redirect-ingress-llm-scads-ai-http
+spec:
+  hostnames:
+    - llm.scads.ai
+  parentRefs:
+    - name: nginx
+      port: 80
+  rules:
+    - filters:
+        - requestRedirect:
+            scheme: https
+            statusCode: 308
+          type: RequestRedirect
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/$.*
+    - filters:
+        - requestRedirect:
+            scheme: https
+            statusCode: 308
+          type: RequestRedirect
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/docs(.*)$.*
+    - filters:
+        - requestRedirect:
+            scheme: https
+            statusCode: 308
+          type: RequestRedirect
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/status(.*)$.*
+    - filters:
+        - requestRedirect:
+            scheme: https
+            statusCode: 308
+          type: RequestRedirect
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/metrics/?.*
+    - filters:
+        - requestRedirect:
+            scheme: https
+            statusCode: 308
+          type: RequestRedirect
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/auth.*
+    - filters:
+        - requestRedirect:
+            scheme: https
+            statusCode: 308
+          type: RequestRedirect
+      matches:
+        - path:
+            type: RegularExpression
+            value: (?i)/.*
+status:
+  parents: null


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind regression
/kind documentation

**What this PR does / why we need it**:

- allows agentgateway traffic policies to target `HTTPRoute` rules with `targetRefs.sectionName` when merged routes are only partially covered
- keeps the remaining invalid case limited to partial backend coverage within a single rule
- skips unsupported partial frontend projection with a warning instead of failing the conversion
- adds issue #110 regression coverage and updates the emitter README

**Which issue(s) this PR fixes**:
Fixes: #110

**Does this PR introduce a user-facing change?**:
```release-note
Fixes the agentgateway emitter so policies that cleanly cover full HTTPRoute rules in merged routes are emitted using rule-scoped targetRefs instead of failing conversion.
```
